### PR TITLE
mutmat io

### DIFF
--- a/src/panmap.cpp
+++ b/src/panmap.cpp
@@ -3,6 +3,7 @@
 #include "pmi.hpp"
 #include "genotype.hpp"
 #include "place.hpp"
+#include "tree.hpp"
 #include <iostream>
 #include <string>
 #include <cstdio>
@@ -16,7 +17,7 @@ namespace po = boost::program_options;
 namespace fs = boost::filesystem;
 
 /* Helpers */
-void promptAndPlace(Tree *T, const int32_t k, const int32_t s, const std::string &indexFile, const std::string &pmatFile, std::string &reads1File, std::string &reads2File, std::string &samFileName, std::string &bamFileName, std::string &mpileupFileName, std::string &vcfFileName, std::string &refFileName, const bool prompt) {
+void promptAndPlace(Tree *T, const int32_t k, const int32_t s, const std::string &indexFile, const std::string &mutmatFile, const std::string &pmatFile, std::string &reads1File, std::string &reads2File, std::string &samFileName, std::string &bamFileName, std::string &mpileupFileName, std::string &vcfFileName, std::string &refFileName, const bool prompt) {
     std::cin.clear();
     std::fflush(stdin);
     using namespace std;
@@ -39,8 +40,9 @@ void promptAndPlace(Tree *T, const int32_t k, const int32_t s, const std::string
         exit(0);
     }
     std::ifstream ifs(indexFile);
+    std::ifstream mfs(mutmatFile);
 
-    place::placeIsolate(ifs, reads1File, reads2File, samFileName, bamFileName, mpileupFileName, vcfFileName, refFileName, T);
+    place::placeIsolate(ifs, mfs, reads1File, reads2File, samFileName, bamFileName, mpileupFileName, vcfFileName, refFileName, T);
 
 }
 void promptAndIndex(Tree *T, const bool prompt, const std::string &indexFile) {
@@ -70,13 +72,14 @@ int main(int argc, char *argv[]) {
             ("reads1", po::value<std::string>(), "Path to first (or single-end) fastq file (optional)")
             ("reads2", po::value<std::string>(), "Path to second paired-end fastq file (optional)")
             ("index,i", po::value<std::string>(), "Path to index file")
+            ("mutmat,u", po::value<std::string>(), "Path to mutation matrix file")
             ("params,p", po::value<std::vector<int32_t>>()->multitoken(), "Specify syncmer parameters k,s for indexing (e.g. for k=13, s=8 use -p 13,8)")
             ("f", "Proceed without prompting for confirmation. Applies to index construction if -p is specified or no index is found at ( /path/to/pmat.pmi ). Applies to sample placement if reads are provided.")
             ("s", po::value<std::string>(), "Path to sam output")
             ("b", po::value<std::string>(), "Path to bam output")
             ("m", po::value<std::string>(), "Path to mpileup output")
             ("v", po::value<std::string>(), "Path to vcf output")
-            ("r", po::value<std::string>(), "Path to vcf output")
+            ("r", po::value<std::string>(), "Path to reference fasta output")
         ;
 
         po::positional_options_description p;
@@ -86,7 +89,9 @@ int main(int argc, char *argv[]) {
         po::variables_map vm;
         po::store(po::command_line_parser(argc, argv).options(desc).positional(p).run(), vm);
         po::notify(vm);
-        std::string pmatFile = vm["panmat"].as<std::string>();
+
+        fs::path pmatFilePathObject = fs::path(vm["panmat"].as<std::string>());
+        std::string pmatFile = fs::canonical(pmatFilePathObject).string();
         
         std::cout << "   ┏━┳━●\033[36;1m\033[1m pan \033[0m" << std::endl;
         std::cout << "  ━┫ ┗━━━●\033[36;1m\033[1m map\033[0m\033[32;1m\033[0m" << std::endl;
@@ -102,7 +107,8 @@ int main(int argc, char *argv[]) {
 
         std::cout << "\nUsing tree: \e[3;1m" << pmatFile << "\e[0m  (" << T->allNodes.size() << " nodes)" << std::endl;
 
-        std::string indexFile = "";
+        std::string indexFile  = "";
+        std::string mutmatFile = "";
         std::string reads1File = "";
         std::string reads2File = "";
         if (vm.count("reads1")) {
@@ -147,8 +153,41 @@ int main(int argc, char *argv[]) {
             indexFile = defaultIndexPath;
         }
 
-
-        //TODO, add some sort of error if all of these are empty, cus then why are we placing
+        // Mutation matrix (mm) file
+        std::string defaultMutmatPath = pmatFile + ".mm";
+        if (vm.count("mutmat")) {
+            mutmatFile = fs::canonical(fs::path(vm["mutmat"].as<std::string>())).string();
+            std::cout << "Using mutation matrix file: " << mutmatFile << std::endl;
+        } else if (fs::exists(defaultMutmatPath)) {
+            mutmatFile = defaultMutmatPath;
+            std::cout << "Mutation matrix file detected, using mutation matrix file: " << defaultMutmatPath << std::endl;
+        } else {
+            std::cout << "No mutation matrix file detected, building mutation matrix ..." << std::endl; 
+            // build mutation matrix
+            tree::mutationMatrices mutMat = tree::mutationMatrices();
+            tree::fillMutationMatricesFromTree(mutMat, T);
+            
+            // write to file
+            std::cout << "Writing to " << defaultMutmatPath << " ...";
+            std::ofstream mmfout(defaultMutmatPath);
+            for (const std::vector<double>& row : mutMat.submat) {
+                for (const double& prob : row) {
+                    mmfout << prob << " ";
+                }
+                mmfout << "\n";
+            }
+            for (const double& prob : mutMat.insmat) {
+                mmfout << prob << " ";
+            }
+            mmfout << "\n";
+            for (const double& prob : mutMat.delmat) {
+                mmfout << prob << " ";
+            }
+            mmfout.close();
+            mutmatFile = defaultMutmatPath;
+        }
+        
+        // TODO, add some sort of error if all of these are empty, cus then why are we placing
         std::string samFileName = "";
         std::string bamFileName = "";
         std::string mpileupFileName = "";
@@ -170,7 +209,7 @@ int main(int argc, char *argv[]) {
             refFileName = vm["r"].as<std::string>();
         }
 
-        promptAndPlace(T, k, s, indexFile, pmatFile, reads1File, reads2File, samFileName, bamFileName, mpileupFileName, vcfFileName, refFileName, prompt);
+        promptAndPlace(T, k, s, indexFile, mutmatFile, pmatFile, reads1File, reads2File, samFileName, bamFileName, mpileupFileName, vcfFileName, refFileName, prompt);
 
     } catch (const std::exception &e) {
         std::cerr << "Error: " << e.what() << std::endl;

--- a/src/place.cpp
+++ b/src/place.cpp
@@ -222,7 +222,7 @@ extern "C" {
 
 
 
-void place::placeIsolate(std::ifstream &indexFile, const std::string &reads1Path, const std::string &reads2Path, std::string &samFileName, std::string &bamFileName, std::string &mpileupFileName, std::string &vcfFileName, std::string &refFileName, Tree *T) {
+void place::placeIsolate(std::ifstream &indexFile, std::ifstream &mmFile, const std::string &reads1Path, const std::string &reads2Path, std::string &samFileName, std::string &bamFileName, std::string &mpileupFileName, std::string &vcfFileName, std::string &refFileName, Tree *T) {
     tree::mutableTreeData data;
     tree::globalCoords_t globalCoords;
     tree::setup(data, globalCoords, T);
@@ -570,13 +570,11 @@ void place::placeIsolate(std::ifstream &indexFile, const std::string &reads1Path
         }
     }
 
-    
-
 
     //Convert to VCF
     //Get mutation matrix.
     mutationMatrices mutMat = mutationMatrices();
-    fillMutationMatrices(mutMat, T);
+    fillMutationMatricesFromFile(mutMat, mmFile);
 
     // Convert c string of mpileup to ifstream
     std::istringstream mpileipStream(mplp_string.s);

--- a/src/place.hpp
+++ b/src/place.hpp
@@ -7,7 +7,7 @@
 
 namespace place {
 
-    void placeIsolate( std::ifstream &indexFile, const std::string &reads1Path, const std::string &reads2Path, std::string &samFileName, std::string &bamFileName, std::string &mpileupFileName, std::string &vcfFileName, std::string &refFileName, PangenomeMAT::Tree *T);
+    void placeIsolate( std::ifstream &indexFile, std::ifstream &mmFile, const std::string &reads1Path, const std::string &reads2Path, std::string &samFileName, std::string &bamFileName, std::string &mpileupFileName, std::string &vcfFileName, std::string &refFileName, PangenomeMAT::Tree *T);
 
 }
 

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -446,30 +446,27 @@ void tree::printMutationMatrices(Tree* T, std::ofstream* ofptr) {
     
 }
 
-void tree::fillMutationMatrices(mutationMatrices& mutMat, Tree* T, std::ifstream* infptr) {
-    if (infptr != nullptr) {
-        // read mutation matrix from file if provided
-        std::string line;
-        int idx = 0;
-        while(getline(*infptr, line)) {
-            std::vector<double> probs;
-            std::vector<std::string> fields;
-            stringSplit(line, ' ', fields);
-            for (const auto& f : fields) {
-                probs.push_back(std::stod(f));
-            }
-            if (idx < 4) {
-                mutMat.submat[idx] = move(probs);
-            } else if (idx == 4) {
-                mutMat.insmat = move(probs);
-            } else {
-                mutMat.delmat = move(probs);
-            }
-            idx++;
-        }
-        return;
-    } else {
-        buildMutationMatrices(mutMat, T);
-    }
+void tree::fillMutationMatricesFromTree(mutationMatrices& mutMat, Tree* T) {
+    buildMutationMatrices(mutMat, T);
+}
 
+void tree::fillMutationMatricesFromFile(mutationMatrices& mutMat, std::ifstream& inf) {
+    std::string line;
+    int idx = 0;
+    while(getline(inf, line)) {
+        std::vector<double> probs;
+        std::vector<std::string> fields;
+        stringSplit(line, ' ', fields);
+        for (const auto& f : fields) {
+            probs.push_back(std::stod(f));
+        }
+        if (idx < 4) {
+            mutMat.submat[idx] = move(probs);
+        } else if (idx == 4) {
+            mutMat.insmat = move(probs);
+        } else {
+            mutMat.delmat = move(probs);
+        }
+        idx++;
+    }
 }

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -82,7 +82,8 @@ namespace tree {
     void setup(mutableTreeData &data, globalCoords_t &globalCoords, Tree *T);
 
     // Fill mutation matrices from tree or file
-    void fillMutationMatrices(mutationMatrices& mutMat, Tree* T, std::ifstream* infptr=nullptr);
+    void fillMutationMatricesFromTree(mutationMatrices& mutMat, Tree* T);
+    void fillMutationMatricesFromFile(mutationMatrices& mutMat, std::ifstream& inf);
 
     // Build mutation matrices by traversing through all parent-child pairs
     void printMutationMatrices(Tree* T, std::ofstream* outfptr=nullptr);


### PR DESCRIPTION
- Changed path to pmat, `pmatFile`, to canonical path (same as absolute path but has no symbolic link, dot, or dot-dot elements) for aesthetics
- accepts path to mutation matrix (mm) file as an argument
  - if no path provided, try to detect mm file in the same directory as input pmat file (look for `pmatFile + '.mm'`  )
  - if no mm file detected, build new mutation matrix and write to `pmatFile + '.mm'` 