### PR TITLE
build: fix capnp install path on lib64 distros

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,9 @@ output
 site
 docs
 recipe
+external_cache
+examples
+data
+llms
+manuscript.md
+review.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ else()
         SOURCE_DIR ${CAPNP_SOURCE_DIR}
         CMAKE_ARGS
             -DCMAKE_INSTALL_PREFIX=${CAPNP_INSTALL_DIR}
+            -DCMAKE_INSTALL_LIBDIR=lib  # force lib/ (not lib64) so the paths below resolve on all distros
             -DCMAKE_BUILD_TYPE=Release
             -DBUILD_TESTING=OFF
         BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config Release -j


### PR DESCRIPTION
Fixes error on lib64 distro: the vendored capnp ExternalProject installs `libcapnp.a` to `lib64/`, but the build hardcodes `lib/`.

Pin the capnp ExternalProject to `-DCMAKE_INSTALL_LIBDIR=lib` so it always installs where the build expects. 

Also trims the Docker build context via `.dockerignore` (excludes `examples`, `data`, etc.).