### PR TITLE
build: conda environment.yml for source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,8 +294,9 @@ else()
     set(PANMAN_TBB_COMPAT "false")
 endif()
 
-if(USE_SYSTEM_LIBS)
-    # Source pre-placed (e.g. the conda recipe's second source tarball); no network fetch.
+if(PANMAN_SOURCE_DIR OR EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/panman")
+    # Source pre-placed (e.g. the conda recipe's second source tarball) or
+    # user-provided via -DPANMAN_SOURCE_DIR; no network fetch.
     if(NOT PANMAN_SOURCE_DIR)
         set(PANMAN_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/panman")
     endif()
@@ -656,6 +657,8 @@ add_dependencies(panmap_lib panman_lib minimap2_target build-deps index_capnp_ge
 # so main.cpp compiles in the identical environment. See target_link_libraries below.
 add_executable(panmap src/main.cpp)
 add_dependencies(panmap panmap_lib build-deps index_capnp_generator tbb_build)
+# Place the binary in build/bin (matches the docs and the simulate/test targets)
+set_target_properties(panmap PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 # Build simulate tool if enabled
 if(OPTION_BUILD_SIMULATE)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ docker pull quay.io/biocontainers/panmap:0.1.1--0
 docker run --rm panmap panmap -h
 ```
 
+Or built from source with conda (no system-level installs):
+
+```bash
+conda env create -f environment.yml
+conda activate panmap
+export CPATH="$CONDA_PREFIX/include" LIBRARY_PATH="$CONDA_PREFIX/lib"
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DUSE_SYSTEM_LIBS=ON && cmake --build build -j
+```
+
 ## Quick start (demo)
 
 ### Single-sample Pipeline

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,7 +28,24 @@ docker run --rm -v $(pwd):/data -w /data alanalohaucsc/panmap:latest \
 
 ## Building from source
 
-### Dependencies
+### With conda (recommended)
+
+The repository ships an `environment.yml` with all build dependencies, so nothing
+needs to be installed system-wide:
+
+```bash
+conda env create -f environment.yml
+conda activate panmap
+export CPATH="$CONDA_PREFIX/include" LIBRARY_PATH="$CONDA_PREFIX/lib"
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DUSE_SYSTEM_LIBS=ON
+cmake --build build -j
+```
+
+`-DUSE_SYSTEM_LIBS=ON` builds against the conda-provided Cap'n Proto, htslib,
+Protobuf, and Abseil; the `CPATH`/`LIBRARY_PATH` exports let the bundled aligners
+find the conda headers and libraries. The binary is at `build/bin/panmap`.
+
+### With system packages
 
 | Package | Ubuntu/Debian |
 |---------|---------------|
@@ -37,15 +54,12 @@ docker run --rm -v $(pwd):/data -w /data alanalohaucsc/panmap:latest \
 | Protobuf | `protobuf-compiler`, `libprotobuf-dev` |
 | Boost | `libboost-program-options-dev`, `libboost-iostreams-dev`, `libboost-filesystem-dev`, `libboost-system-dev`, `libboost-date-time-dev` |
 | zlib | `zlib1g-dev` |
-| htslib | `libhts-dev` |
-| Cap'n Proto | `capnproto`, `libcapnp-dev` |
 | Eigen3 | `libeigen3-dev` |
-
-### Build
 
 ```bash
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build -j$(nproc)
 ```
 
-The binary is at `build/bin/panmap`.
+The binary is at `build/bin/panmap`. Cap'n Proto and htslib are built from the
+bundled sources automatically.

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,30 @@
+# Conda environment for building panmap from source (no system-level installs).
+#   conda env create -f environment.yml
+#   conda activate panmap
+#   export CPATH="$CONDA_PREFIX/include" LIBRARY_PATH="$CONDA_PREFIX/lib"
+#   cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DUSE_SYSTEM_LIBS=ON
+#   cmake --build build -j
+# The binary is at build/bin/panmap.
+name: panmap
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - cmake
+  - make
+  - compilers
+  - pkg-config
+  - git
+  - libprotobuf
+  - capnproto
+  - htslib
+  - libboost-devel
+  - tbb-devel
+  - libabseil
+  - jsoncpp
+  - spdlog
+  - fmt
+  - zstd
+  - libdeflate
+  - zlib
+  - eigen


### PR DESCRIPTION
Adds conda env file so building from source doesn't need system-wide dependency installs.

- Adds `environment.yml` with all build dependencies.
- Build with `-DUSE_SYSTEM_LIBS=ON` so the conda-provided Cap'n Proto, htslib, Protobuf, and Abseil are used.
