### PR TITLE
DIAG: capture Test 5 abort (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,35 @@ jobs:
         run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DOPTION_BUILD_TESTS=ON
       - name: Build
         run: cmake --build build -j"$(nproc)"
-      - name: Test
-        run: ctest --test-dir build --output-on-failure -j2
+      - name: Diagnose Test 5 abort (stress loop + backtrace)
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq gdb
+          echo '/tmp/core.%p' | sudo tee /proc/sys/kernel/core_pattern
+          ulimit -c unlimited
+          T=$(mktemp -d); cp src/test/data/rsv_4K.panman "$T/"
+          NODE=src/test/data/rsv_4K.panman.random.node_1330.fa
+          build/bin/panmap "$T/rsv_4K.panman" --stop index -t 2 >/dev/null 2>&1
+          ab=0
+          for i in $(seq 1 100); do
+            if ! build/bin/panmap "$T/rsv_4K.panman" "$NODE" --stop genotype -o "$T/g" -t 2 >"$T/out" 2>&1; then
+              rc=$?; ab=$((ab+1))
+              echo "==================== ABORT run $i (exit $rc) ===================="
+              echo "----- output -----"; cat "$T/out"
+              core=$(ls -t /tmp/core.* 2>/dev/null | head -1)
+              if [ -n "$core" ]; then
+                echo "----- backtrace ($core) -----"
+                gdb -batch -ex 'bt' build/bin/panmap "$core" 2>&1 | head -50
+              fi
+              break
+            fi
+          done
+          echo "aborts in 100 runs: $ab"
+          true
 
-  # Cross-platform safety net. macOS runners bill ~10x, so only on push to main.
-  build-test-macos:
+  # (macos + docker jobs omitted on this diagnostic branch)
+  _unused-macos:
     name: build & test (macos)
-    if: github.event_name == 'push'
+    if: false
     runs-on: macos-14
     defaults:
       run:
@@ -62,6 +84,7 @@ jobs:
   # Validates the vendored from-source build path and the shipped image.
   docker:
     name: docker build
+    if: false  # disabled on diagnostic branch
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/src/mm_align.c
+++ b/src/mm_align.c
@@ -67,6 +67,13 @@ static mm_idx_t* setup_minimap2(mm_idxopt_t* iopt,
 
     mm_verbose = 0;  // suppress warnings
 
+    // Initialize ALL options to minimap2 defaults before applying any preset. mm_set_opt
+    // with a named preset only sets a subset of fields; the map-ont/map-hifi branches
+    // below do not otherwise initialize mopt, so occupancy fields (e.g. mid_occ_frac)
+    // would be read from uninitialized stack memory. That garbage reaches
+    // mm_mapopt_update -> mm_idx_cal_max_occ and causes a flaky out-of-bounds crash.
+    mm_set_opt(0, iopt, mopt);
+
     if (avg_len < 500) {
         if (for_scoring) {
             // Replicate minimap2 sr preset scoring/index params exactly.
@@ -75,7 +82,6 @@ static mm_idx_t* setup_minimap2(mm_idxopt_t* iopt,
             // Without MM_F_SR, minimap2 uses gapped alignment — same scoring params,
             // correct results, no crash.  We still set MM_F_FRAG_MODE + MM_F_HEAP_SORT
             // so mm_map_frag pairs reads correctly.
-            mm_set_opt(0, iopt, mopt);
             // Index params (same as sr)
             iopt->k = 21;
             iopt->w = 11;


### PR DESCRIPTION
Temporary diagnostic branch to capture the flaky native-x86-64 SIGABRT in Test 5 (internal-node .fa genotype). Stress-loops the command 100x with stderr + gdb backtrace. Not for merge.