### PR TITLE
docs(meta): fix broken/stale flags in metagenomic.md

### DIFF
--- a/docs/metagenomic.md
+++ b/docs/metagenomic.md
@@ -59,10 +59,15 @@ Output: `SRR19707934.mgsr.abundance.out` -- estimated node abundances.
 ### 3. Identify lineages
 
 ```bash
-panmap ../examples/data/sars_20000_twilight_dipper.panman \
-  --dump-sequences "$(cut -f1 SRR19707934.mgsr.abundance.out \
-    | tr ',' '\n' | grep '\S' | tr '\n' ' ' | sed 's/ $//g')" \
-  --output SRR19707934
+# Extract the reference sequence for each abundant node into one FASTA.
+# --dump-sequence writes one node per call, so loop over the abundance output.
+: > SRR19707934.dump-sequences.fa
+cut -f1 SRR19707934.mgsr.abundance.out | tr ',' '\n' | grep '\S' | while IFS= read -r node; do
+  panmap ../examples/data/sars_20000_twilight_dipper.panman \
+    --dump-sequence "$node" -o node.fa >/dev/null
+  cat node.fa >> SRR19707934.dump-sequences.fa
+done
+rm -f node.fa
 
 pangolin SRR19707934.dump-sequences.fa \
   --outfile SRR19707934.pangolin.csv
@@ -144,7 +149,8 @@ panmap ../examples/data/v_mtdna.panman \
 | `--discard` | Discard reads with parsimony score < threshold * total seeds | `0.0` (no discard) |
 | `--mask-read-ends` | Mask N bases from read ends (for aeDNA damage) | `0` |
 | `--taxonomic-metadata <file>` | TSV with taxonomic metadata per node | -- |
-| `--maximum-families` | Discard reads spanning > N taxonomic families | `1` |
+| `--taxonomic-rank` | Taxonomic rank (column in the metadata TSV) to filter/assign on | `Family` |
+| `--maximum-taxon-number` | Discard reads spanning more than N distinct taxa at that rank | `1` |
 | `--ambiguous-score-threshold-ratio` | Discard reads scoring outside max families by ratio | `0.0` |
 | `--ambiguous-score-threshold` | Discard reads scoring outside max families by absolute value | `0` |
 | `--breadth-ratio` | Calculate observed/expected breadth ratio | off |


### PR DESCRIPTION
Two flag fixes in the metagenomic docs:

1. **Lineage-ID step** used `--dump-sequences` (plural) — not a real flag. Replaced with a loop over the abundant nodes using the real `--dump-sequence` (one node per call), concatenating into the FASTA pangolin reads. Loop mechanics verified locally.
2. **Options table** listed `--maximum-families`, which was renamed to `--maximum-taxon-number`; also added the related `--taxonomic-rank`. (Matches the fix already made in the CLI reference.)

Metagenomic mode is your coauthor's area — worth their eyes on the surrounding workflow, but both flags were unambiguously wrong.