### PR TITLE
fix(seeding): reverse R2 base qualities when reverse-complementing R2 reads

### DIFF
--- a/src/seeding.cpp
+++ b/src/seeding.cpp
@@ -231,9 +231,13 @@ void readFastqPaired(std::vector<std::string>& readSequences,
         seq = kseq_init(fileno(fq2.fp));
         int forwardReads = readSequences.size();
         while (kseq_read(seq) >= 0) {
+            // R2 is reverse-complemented, so its per-base qualities must be
+            // reversed (not complemented) to stay aligned with the bases.
             readSequences.push_back(reverseComplement(seq->seq.s));
             readNames.push_back(seq->name.s);
-            readQuals.push_back(seq->qual.l > 0 ? seq->qual.s : std::string(seq->seq.l, 'I'));
+            std::string r2qual = seq->qual.l > 0 ? std::string(seq->qual.s) : std::string(seq->seq.l, 'I');
+            std::reverse(r2qual.begin(), r2qual.end());
+            readQuals.push_back(std::move(r2qual));
         }
         kseq_destroy(seq);
 

--- a/src/seeding.cpp
+++ b/src/seeding.cpp
@@ -232,7 +232,7 @@ void readFastqPaired(std::vector<std::string>& readSequences,
         int forwardReads = readSequences.size();
         while (kseq_read(seq) >= 0) {
             // R2 is reverse-complemented, so its per-base qualities must be
-            // reversed (not complemented) to stay aligned with the bases.
+            // reversed to stay aligned with the bases.
             readSequences.push_back(reverseComplement(seq->seq.s));
             readNames.push_back(seq->name.s);
             std::string r2qual = seq->qual.l > 0 ? std::string(seq->qual.s) : std::string(seq->seq.l, 'I');


### PR DESCRIPTION
 Reverse the quality string for reverse complemented reads

