### PR TITLE
fix(genotyping): guard out-of-bounds ALT index in substitution-spectrum prior

### DIFF
--- a/src/genotyping.cpp
+++ b/src/genotyping.cpp
@@ -226,7 +226,14 @@ std::string genotyping::applyMutationSpectrum(const std::string& line,
 
     gls[0] += scaled_submat[ref_nuc_idx][ref_nuc_idx];
     for (int i = 1; i < gls.size(); i++) {
-        gls[i] = gls[i] + scaled_submat[ref_nuc_idx][getIndexFromNucleotide(alts[i - 1])];
+        // scaled_submat is the 4x4 A/C/G/T substitution-spectrum prior, so only
+        // apply it for base ALTs. A non-base ALT (e.g. '*' spanning deletion)
+        // yields an index > 3 that would over-read the row; leave its likelihood
+        // unmodified (matching how indels use the unmodified bcftools posterior).
+        int alt_idx = getIndexFromNucleotide(alts[i - 1]);
+        if (alt_idx <= 3) {
+            gls[i] = gls[i] + scaled_submat[ref_nuc_idx][alt_idx];
+        }
     }
 
     double min_gl = *std::min_element(gls.begin(), gls.end());


### PR DESCRIPTION
applyMutationSpectrum validated the REF allele to A/C/G/T but not the ALT.

Only apply the prior for A/C/G/T ALTs.

