### PR TITLE
fix: correctness (HPC quality, simulate-snps, bcftools rc, kminmer end() deref)

### DIFF
--- a/src/conversion.cpp
+++ b/src/conversion.cpp
@@ -3,6 +3,7 @@
 #include "logging.hpp"
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <unistd.h>
@@ -95,11 +96,12 @@ void createMplpBcf(const std::string& prefix,
         mpileupFileName = prefix + ".mpileup";
     }
 
+    int rc = 0;
     {
         if (baq) {
             const char* mpileup_args[] = {
                 "mpileup", "-Ou", "-f", outRefFileName.c_str(), "-o", mpileupFileName.c_str(), bamFileName.c_str()};
-            run_bcftools_in_fork(main_mpileup, 7, const_cast<char**>(mpileup_args));
+            rc = run_bcftools_in_fork(main_mpileup, 7, const_cast<char**>(mpileup_args));
         } else {
             const char* mpileup_args[] = {"mpileup",
                                           "-Ou",
@@ -109,8 +111,12 @@ void createMplpBcf(const std::string& prefix,
                                           "-o",
                                           mpileupFileName.c_str(),
                                           bamFileName.c_str()};
-            run_bcftools_in_fork(main_mpileup, 8, const_cast<char**>(mpileup_args));
+            rc = run_bcftools_in_fork(main_mpileup, 8, const_cast<char**>(mpileup_args));
         }
+    }
+    if (rc != 0) {
+        output::error("bcftools mpileup failed (exit code {}) for {}", rc, bamFileName);
+        std::exit(1);
     }
 }
 
@@ -127,7 +133,11 @@ void createVcfWithMutationMatrices(std::string& prefix,
     {
         const char* call_args[] = {
             "call", "--ploidy", "1", "-c", "-A", "-O", "v", "-o", rawVcfFile.c_str(), mpileupFileName.c_str()};
-        run_bcftools_in_fork(main_vcfcall, 10, const_cast<char**>(call_args));
+        int rc = run_bcftools_in_fork(main_vcfcall, 10, const_cast<char**>(call_args));
+        if (rc != 0) {
+            output::error("bcftools call failed (exit code {})", rc);
+            std::exit(1);
+        }
     }
 
     std::ifstream rawVcfIn(rawVcfFile);

--- a/src/index_single_mode.cpp
+++ b/src/index_single_mode.cpp
@@ -923,10 +923,12 @@ void index_single_mode::IndexBuilder::buildIndexHelper(panmanUtils::Node* node,
 
     for (size_t i = 0; i < newKminmerRanges.size(); i++) {
         auto beg = *newKminmerRanges[i].first;
-        auto end = *newKminmerRanges[i].second;
-        if (newKminmerRanges[i].second != refOnSyncmersMap.end() && beg > end) {
-            output::error("beg ({}) > end ({}) in node {}", beg, end, node->identifier);
-            std::exit(1);
+        if (newKminmerRanges[i].second != refOnSyncmersMap.end()) {
+            auto end = *newKminmerRanges[i].second;   // only deref when not end()
+            if (beg > end) {
+                output::error("beg ({}) > end ({}) in node {}", beg, end, node->identifier);
+                std::exit(1);
+            }
         }
         if (i != 0 && *newKminmerRanges[i - 1].second > beg) {
             output::error("newKminmerRanges[{}].second ({}) > newKminmerRanges[{}].first ({}) in node {}",
@@ -1841,10 +1843,12 @@ void index_single_mode::IndexBuilder::processNode(panmanUtils::Node* node,
 
     for (size_t i = 0; i < newKminmerRanges.size(); i++) {
         auto beg = *newKminmerRanges[i].first;
-        auto end = *newKminmerRanges[i].second;
-        if (newKminmerRanges[i].second != state.refOnSyncmersMap.end() && beg > end) {
-            output::error("beg ({}) > end ({}) in node {}", beg, end, node->identifier);
-            std::exit(1);
+        if (newKminmerRanges[i].second != state.refOnSyncmersMap.end()) {
+            auto end = *newKminmerRanges[i].second;   // only deref when not end()
+            if (beg > end) {
+                output::error("beg ({}) > end ({}) in node {}", beg, end, node->identifier);
+                std::exit(1);
+            }
         }
         if (i != 0 && *newKminmerRanges[i - 1].second > beg) {
             output::error("newKminmerRanges[{}].second > newKminmerRanges[{}].first", i - 1, i);

--- a/src/panmap_utils.cpp
+++ b/src/panmap_utils.cpp
@@ -228,9 +228,22 @@ void simulateSNPsOnSequence(
   std::uniform_int_distribution<uint32_t> distNuc(0, 2);
   snpRecords.clear();
   snpRecords.reserve(numsnps);
-  std::uniform_int_distribution<uint32_t> distPos(1000, sequence.size() - 1000);
+  // Sampling window: skip a 1000 bp flank when the sequence is long enough, else use
+  // the whole sequence (guards size_t underflow of size()-1000 and lo>hi UB on short seqs).
+  uint32_t lo, hi;
+  if (sequence.size() > 2u * 1000u) {
+    lo = 1000;
+    hi = static_cast<uint32_t>(sequence.size()) - 1000;
+  } else if (!sequence.empty()) {
+    lo = 0;
+    hi = static_cast<uint32_t>(sequence.size()) - 1;
+  } else {
+    return;
+  }
+  std::uniform_int_distribution<uint32_t> distPos(lo, hi);
   std::unordered_set<uint32_t> visitedPositions;
-  while (snpRecords.size() < numsnps) {
+  const size_t windowSize = static_cast<size_t>(hi) - lo + 1;   // stop once every position has been tried
+  while (snpRecords.size() < numsnps && visitedPositions.size() < windowSize) {
     uint32_t pos = distPos(rng);
     if (visitedPositions.find(pos) != visitedPositions.end()) continue;
     visitedPositions.insert(pos);

--- a/src/placement.cpp
+++ b/src/placement.cpp
@@ -1021,13 +1021,28 @@ void placeLite(PlacementResult& result,
             }
         }
 
-        // Apply homopolymer compression to reads if the index was built with HPC
+        // Apply homopolymer compression to reads if the index was built with HPC.
+        // When quality filtering is active, compress each quality string in lockstep
+        // (keep the first base's quality per run) so per-seed quality lookups stay
+        // aligned with the compressed sequence coordinates.
         if (params.hpc && !allReadSequences.empty()) {
             logging::info("HPC mode: compressing read sequences");
+            const bool compressQual = params.minSeedQuality > 0 && !allReadQualities.empty();
             tbb::parallel_for(tbb::blocked_range<size_t>(0, allReadSequences.size()),
                               [&](const tbb::blocked_range<size_t>& range) {
                                   for (size_t i = range.begin(); i < range.end(); ++i) {
-                                      allReadSequences[i] = seeding::hpcCompress(allReadSequences[i]);
+                                      if (compressQual && i < allReadQualities.size() &&
+                                          allReadQualities[i].size() == allReadSequences[i].size()) {
+                                          auto [compressed, mapping] =
+                                              seeding::hpcCompressWithMapping(allReadSequences[i]);
+                                          std::string cq;
+                                          cq.reserve(mapping.size());
+                                          for (size_t m : mapping) cq.push_back(allReadQualities[i][m]);
+                                          allReadSequences[i] = std::move(compressed);
+                                          allReadQualities[i] = std::move(cq);
+                                      } else {
+                                          allReadSequences[i] = seeding::hpcCompress(allReadSequences[i]);
+                                      }
                                   }
                               });
         }


### PR DESCRIPTION
Fixes quality strings in HPC mode.

Fixes potential infinite loop in simulateSnps.

Checks return code of bcftools.