### PR TITLE
Wire up --aligner bwa; clarify option modes; fix doc inaccuracies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -614,6 +614,7 @@ set(PANMAP_LIB_SOURCES
     src/seeding.cpp
     src/mgsr.cpp
     src/mm_align.c
+    src/bwa_align.c
     src/pileup.c
     src/zstd_compression.cpp
     ${LITE_CAPNP_SRCS}
@@ -658,11 +659,12 @@ add_dependencies(panmap panmap_lib build-deps index_capnp_generator tbb_build)
 set_target_properties(panmap PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
 if(OPTION_BUILD_SIMULATE)
-    add_executable(simulate 
+    add_executable(simulate
         src/test/simulate.cpp
         src/genotyping.cpp
         src/conversion.cpp
         src/mm_align.c
+        src/bwa_align.c
         src/pileup.c
     )
     
@@ -682,6 +684,7 @@ if(OPTION_BUILD_SIMULATE)
     target_link_libraries(simulate PRIVATE
         panman_lib
         minimap2
+        bwa
         bcftools
         htslib
         libdeflate_shared

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,13 +43,12 @@ See `TESTING.md` for details.
 - Use `const` references for read-only parameters
 - Add `[[nodiscard]]` to functions returning error codes
 
-Formatting is checked in CI (the `format` job runs `clang-format --dry-run
---Werror` over first-party sources). Run `clang-format -i` on your changes
-before opening a PR.
+Formatting is not enforced in CI. Run `clang-format -i` over your changed
+`src/` files before opening a PR.
 
 ## Pull requests
 
 1. Create a feature branch from `main`
 2. Ensure `ctest --test-dir build --output-on-failure` passes (unit + e2e)
-3. Ensure the `format` check passes (`clang-format --dry-run --Werror`)
+3. Run `clang-format -i` over changed `src/` files
 4. Keep commits focused and messages concise

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ panmap -h
 With Docker (pulled from registry):
 
 ```bash
-docker pull quay.io/biocontainers/panmap:0.1.1--0
-docker run --rm panmap panmap -h
+docker pull quay.io/biocontainers/panmap:0.1.2--0
+docker run --rm quay.io/biocontainers/panmap:0.1.2--0 panmap -h
 ```
 
 Or build locally with Docker (~6 min):
@@ -78,7 +78,7 @@ Outputs (prefix defaults to the reads filename, `isolate_R1`):
 | `.consensus.fa` | sample consensus |
 
 
-By default, panmap runs the full pipeline (`index → place → align → genotype → consensus`). Use `--stop <stage>` to run fewer stages.
+By default, panmap runs the full pipeline (`index → place → align → genotype → consensus`). Use `--stop <stage>` to run fewer stages (single-sample only; ignored with `--meta`).
 
 
 ## Metagenomic mode (`--meta`)
@@ -109,17 +109,18 @@ panmap --meta --filter-and-assign [options] <pangenome.panman> <reads...>
 **Example** (~2.5 min):
 
 ```bash
-cp data/vertebrate_mtdna/v_mtdna.panman examples/data/
-panmap examples/data/v_mtdna.panman examples/data/subsampled.fastq.gz \
+mkdir -p examples/output
+panmap data/vertebrate_mtdna/v_mtdna.panman examples/data/subsampled.fastq.gz \
        --meta --filter-and-assign -k 15 -s 8 -l 1 --discard 0.6 --dust 5 \
-       --breadth-ratio -t 4 --taxonomic-metadata examples/data/v_mtdna.meta.tsv -o examples/output/subsampled
+       --breadth-ratio -t 4 --taxonomic-metadata data/vertebrate_mtdna/v_mtdna.meta.tsv -o examples/output/subsampled
 ```
 
-Writes three files (prefix `examples/output/subsampled`):
+Writes (prefix `examples/output/subsampled`):
 
 - `.mgsr.assignedReads.fastq`: the reads that were assigned
 - `.mgsr.assignedReads.out`: per node, number of reads assigned and their indices into the fastq
 - `.mgsr.assignedReadsLCANode.out`: per LCA node, number of reads assigned and their indices; a read's LCA node is the LCA of all nodes it was assigned to
+- `.mgsr.breadths.out`: observed/expected breadth ratio per node (from `--breadth-ratio`)
 
 ## Verify
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,80 +4,89 @@
 panmap <panman> [reads1.fq] [reads2.fq] [options]
 ```
 
-Use `--help` for common options or `--help-all` for the full list. This page
-mirrors `panmap --help-all` for version 0.1.2.
+`--help` shows the common (all-modes) and single-sample options; `--help-all`
+adds index & seeding, metagenomic, and developer options. This page mirrors
+`panmap --help-all` for version 0.1.2. Options are grouped by mode: all modes,
+index & seeding (both modes), single-sample (default mode; ignored with
+`--meta`), and metagenomic (require `--meta`).
 
-## General
+A plain single-sample run executes the full `index -> place -> align ->
+genotype -> consensus` pipeline; panmap derives and caches the index from the
+panman automatically, so `-i/--index` is only needed to point at an index in a
+non-default location.
+
+## Options (all modes)
+
+Shown in `--help`.
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `-h, --help` | Show common options | -- |
+| `-h, --help` | Show common + single-sample options | -- |
 | `--help-all` | Show all options | -- |
 | `-V, --version` | Show version | -- |
 | `-o, --output` | Output file prefix | derived from reads filename |
 | `-t, --threads` | Number of threads | `1` |
-| `--stop` | Stop after: `index`, `place`, `align`, `genotype`, `consensus` | `consensus` |
 | `--meta` | Enable metagenomic mode | off |
-| `-a, --aligner` | `minimap2` or `bwa` | `minimap2` |
 | `-v, --verbose` | Verbose output | off |
 | `-q, --quiet` | Errors only | off |
 | `--no-color` | Disable colored output | off |
+| `--batch` | Batch file, one sample per line: `reads1 [reads2] [output_prefix]` (works in both modes) | -- |
 
-## Index
+## Index & seeding (both modes)
+
+The index is built (or reused) the same way for single-sample and `--meta`
+runs. Its path derives from the panman (`<panman>.idx`, `.midx` under `--meta`),
+independent of `-o`; `--meta` rejects a `.idx` index.
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-i, --index` | Load a pre-built index from this path | auto-built at `<panman>.idx` (`.midx` under `--meta`) |
 | `--index-out` | Write the built index to this path | next to the panman |
 | `-f, --reindex` | Force rebuild index | off |
-| `--index-packed` | Build packed Cap'n Proto message | off |
-| `--read-packed` | Read packed Cap'n Proto message | off |
-| `--zstd-level` | ZSTD compression level for index (1-22) | `7` |
-
-## Seed parameters
-
-| Option | Description | Default |
-|--------|-------------|---------|
 | `-k, --kmer` | Syncmer k-mer length | `19` |
 | `-s, --syncmer` | Syncmer s parameter | `8` |
-| `-l, --lmer` | Syncmers per seed | `3` |
 | `--offset` | Syncmer offset | `0` |
+| `-l, --lmer` | Syncmers per seed | `3` |
 | `--open-syncmer` | Use open syncmers | off |
 | `--hpc` | Homopolymer-compressed seeds | off |
 | `--flank-mask` | Mask bp at ends of genomes | `250` |
 | `--seed-mask-fraction` | Mask top seed fraction | `0` |
-| `--min-seed-quality` | Minimum Phred score for seed region | `0` |
-| `--min-read-support` | Minimum reads for a seed (2 = filter singletons) | `1` |
 | `--extent-guard` | Guard seed deletions at genome extent boundaries | off |
+| `--impute` | Impute N's from parent (skip `_->N` mutations in indexing and output) | off |
+| `--zstd-level` | ZSTD compression level for index (1-22) | `7` |
 
-## Read processing
+## Single-sample options (default mode; ignored with `--meta`)
+
+The `place -> align -> genotype -> consensus` pipeline. Ignored under `--meta`,
+which runs its own read-assignment/abundance flow instead.
 
 | Option | Description | Default |
 |--------|-------------|---------|
+| `--stop` | Stop after: `index`, `place`, `align`, `genotype`, `consensus` | `consensus` |
+| `-a, --aligner` | Aligner: `minimap2` or `bwa` (bwa-mem backend) | `minimap2` |
+| `--dedup` | Deduplicate reads | off |
 | `--trim-start` | Trim bases from read start | `0` |
 | `--trim-end` | Trim bases from read end | `0` |
-| `--dedup` | Deduplicate reads | off |
-
-## Placement
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--force-leaf` | Restrict placement to leaf nodes (auto-enabled unless `--stop place`) | off |
+| `--min-seed-quality` | Minimum Phred score for seed region | `0` |
+| `--min-read-support` | Min reads for a seed; `-1`=auto (filter singletons only when est. coverage >3x), `1`=keep all, `2`=filter singletons | `-1` |
+| `--force-leaf` | Restrict placement to leaf nodes only (default unless `--stop place`) | off |
+| `--no-mutation-spectrum` | Disable mutation-spectrum filtering in VCF genotyping | off |
+| `--baq` | Enable Base Alignment Quality in mpileup | off |
 | `--refine` | Alignment-based refinement of top candidates | off |
 | `--refine-top-pct` | Top fraction of nodes to refine | `0.01` |
 | `--refine-max-top-n` | Max nodes to align against | `150` |
 | `--refine-neighbor-radius` | Expand to neighbors within N branches | `2` |
 | `--refine-max-neighbor-n` | Max additional nodes from neighbor expansion | `150` |
 
-## Genotyping
+## Metagenomic options (require `--meta`)
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `--impute` | Impute N's from parent (skip `_->N` mutations) | off |
-| `--no-mutation-spectrum` | Disable mutation-spectrum filtering in VCF | off |
-| `--baq` | Enable Base Alignment Quality in mpileup | off |
+| `--index-packed` | Build packed Cap'n Proto message | off |
+| `--read-packed` | Read packed Cap'n Proto message | off |
+| `--no-progress` | Disable progress bars | off |
 
-## Metagenomic: EM algorithm
+## Metagenomic: EM (require `--meta`)
 
 | Option | Description | Default |
 |--------|-------------|---------|
@@ -92,9 +101,8 @@ mirrors `panmap --help-all` for version 0.1.2.
 | `--em-maximum-rounds` | Maximum EM rounds | `5` |
 | `--em-maximum-iterations` | Maximum EM iterations per round | `1000` |
 | `--em-leaves-only` | Only run EM on leaf (sample) nodes | off |
-| `--no-progress` | Disable progress bars | off |
 
-## Metagenomic: filter and assign
+## Metagenomic: filter and assign (require `--meta`)
 
 | Option | Description | Default |
 |--------|-------------|---------|
@@ -110,12 +118,6 @@ mirrors `panmap --help-all` for version 0.1.2.
 | `--breadth-ratio` | Compute observed/expected breadth ratio | off |
 | `--pseudochain` | Use pseudo-chains for read scoring | off |
 | `--batch-size` | Batch size for filtering and assigning | `1000000` |
-
-## Batch mode
-
-| Option | Description | Default |
-|--------|-------------|---------|
-| `--batch` | File listing samples, one per line: `reads1 [reads2] [output_prefix]` (works in normal and `--meta` modes) | -- |
 
 ## Developer
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -88,7 +88,7 @@ short:
 | Dependency | Ubuntu / Debian package |
 |------------|-------------------------|
 | CMake ≥ 3.14 | `cmake` |
-| C++17 compiler | `g++` or `clang++` |
+| C++20 compiler | `g++` or `clang++` |
 | Protobuf | `protobuf-compiler`, `libprotobuf-dev` |
 | Boost | `libboost-program-options-dev`, `libboost-iostreams-dev`, `libboost-filesystem-dev`, `libboost-system-dev`, `libboost-date-time-dev` |
 | zlib | `zlib1g-dev` |

--- a/docs/metagenomic.md
+++ b/docs/metagenomic.md
@@ -85,13 +85,13 @@ these parameters on first run):
 ```bash
 mkdir example_run && cd example_run
 
-panmap ../examples/data/v_mtdna.panman \
+panmap ../data/vertebrate_mtdna/v_mtdna.panman \
   ../examples/data/subsampled.fastq.gz \
   --meta \
   -k 15 -s 8 -l 1 \
   --filter-and-assign \
   --discard 0.6 --dust 5 \
-  --taxonomic-metadata ../examples/data/v_mtdna.meta.tsv \
+  --taxonomic-metadata ../data/vertebrate_mtdna/v_mtdna.meta.tsv \
   -t 4 --breadth-ratio \
   --output subsampled
 ```
@@ -103,12 +103,15 @@ panmap ../examples/data/v_mtdna.panman \
 | `.mgsr.assignedReads.fastq` | Assigned reads |
 | `.mgsr.assignedReads.out` | Read count and indices per node |
 | `.mgsr.assignedReadsLCANode.out` | Read count and indices for the LCA of each read's assigned nodes |
+| `.mgsr.breadths.out` | Per-node observed vs. expected breadth; written only with `--breadth-ratio` |
 
 ---
 
 ## Metagenomic options reference
 
 ### Indexing
+
+`--index`, `--index-out`, and `--reindex` apply to both modes; `--index-packed`, `--read-packed`, and `--no-progress` require `--meta`. Under `--meta` the index is the `.midx` MGSR index (a single-sample `.idx` index is rejected); its path is derived from the panman (or `--index-out`) and is not affected by `-o`.
 
 | Option | Description | Default |
 |--------|-------------|---------|
@@ -120,6 +123,8 @@ panmap ../examples/data/v_mtdna.panman \
 | `--no-progress` | Disable progress bars | off |
 
 ### EM algorithm
+
+These options require `--meta`.
 
 | Option | Description | Default |
 |--------|-------------|---------|
@@ -136,6 +141,8 @@ panmap ../examples/data/v_mtdna.panman \
 | `--em-leaves-only` | Only run EM on leaf (sample) nodes | off |
 
 ### Filter and assign
+
+These options require `--meta`, except `--batch`, which works in both modes.
 
 | Option | Description | Default |
 |--------|-------------|---------|

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -38,7 +38,7 @@ The metrics score how well the sample's seeds match each node's seed set:
 | `log_raw` | Log of the raw number of shared seeds |
 | `log_cosine` | Log cosine similarity of the seed-count vectors |
 | `containment` | Fraction of the sample's seeds contained in the node |
-| `weighted_containment` | Containment weighted by seed multiplicity |
+| `weighted_containment` | Containment with each shared seed weighted by `1/(node genome count)`, up-weighting seeds that are rare across genomes |
 | `log_containment` | Log-scaled containment (the default placement score) |
 
 The reference for alignment and genotyping is the node chosen by
@@ -74,6 +74,8 @@ Germany/IMS-10036-.../2021|OU071802.1|2021-02-03 0.15086
 | `sample.mgsr.assignedReads.fastq` | The reads that were assigned |
 | `sample.mgsr.assignedReads.out` | Per node: number of reads assigned and their indices into the FASTQ |
 | `sample.mgsr.assignedReadsLCANode.out` | Per LCA node: assigned-read counts and indices (a read's LCA node is the LCA of all nodes it was assigned to) |
+
+Adding `--breadth-ratio` also writes `sample.mgsr.breadths.out` (per node: observed vs. expected seed breadth and depth).
 
 ## Indexes
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -37,13 +37,18 @@ Output: `sample.mgsr.abundance.out`
 
 ## Partial pipelines
 
-```bash
-# Place reads (default)
-panmap ref.panman reads.fq -o sample
+A plain run executes the full pipeline (place -> align -> genotype -> consensus)
+and writes `.bam`, `.vcf`, and `.consensus.fa`. Use `--stop` to end earlier:
 
-# Place and align, skip genotyping
+```bash
+# Stop at placement (writes .placement.tsv only)
+panmap ref.panman reads.fq --stop place -o sample
+
+# Place and align, skip genotyping and consensus
 panmap ref.panman reads.fq --stop align -o sample
 ```
+
+The `--stop` place/align/genotype/consensus stages are single-sample. With `--meta`, only `--stop index` applies (build the `.midx` and stop); the later stages don't run.
 
 ## Managing indexes
 

--- a/docs/single-sample.md
+++ b/docs/single-sample.md
@@ -86,7 +86,7 @@ Mode column: `all` = applies to single-sample and `--meta`; `single` = single-sa
 ## Choosing an aligner (single-sample only, ignored with `--meta`)
 
 - **minimap2** (default): fast, good for most cases
-- **bwa** (`-a bwa`): bwa-mem backend; higher sensitivity, may be preferable for short reads
+- **bwa** (`-a bwa`): bwa-mem backend; higher sensitivity, may be preferable for very short or ancient reads
 
 ```bash
 panmap ref.panman reads.fq -a bwa -o sample

--- a/docs/single-sample.md
+++ b/docs/single-sample.md
@@ -41,10 +41,12 @@ ls examples/data/sars_20000_twilight_dipper.panman
 
 ### 2. Run the full pipeline
 
+Runs index -> place -> align -> genotype -> consensus by default, and auto-builds/reuses the index next to the PanMAN.
+
 ```bash
 panmap examples/data/sars_20000_twilight_dipper.panman \
   reads_R1.fq.gz reads_R2.fq.gz \
-  --stop genotype -t 8 -o my_sample
+  -t 8 -o my_sample
 ```
 
 ### 3. Output files
@@ -60,35 +62,37 @@ The seed index is built once next to the PanMAN (`sars_20000_twilight_dipper.pan
 
 ### 4. Reuse the index
 
-Use `--reindex` to force a rebuild, or `--index <path>` to load a pre-built index from another location:
+The cached index is reused automatically for later samples: just run panmap again. Use `--reindex` to force a rebuild, or `--index <path>` to load a pre-built index from another location.
 
 ```bash
 panmap examples/data/sars_20000_twilight_dipper.panman \
   sample2_R1.fq.gz sample2_R2.fq.gz \
-  --stop consensus -t 8 -o sample2
+  -t 8 -o sample2
 ```
 
 ## Common options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-o, --output` | Output file prefix | derived from reads filename |
-| `-t, --threads` | Number of threads | `1` |
-| `-a, --aligner` | `minimap2` or `bwa` | `minimap2` |
-| `--stop` | Stop after: `index`, `place`, `align`, `genotype`, `consensus` | `consensus` |
-| `--force-leaf` | Restrict placement to leaf nodes | off (auto-enabled unless `--stop place`) |
-| `--refine` | Alignment-based refinement of top candidates | off |
+Mode column: `all` = applies to single-sample and `--meta`; `single` = single-sample only, ignored with `--meta`.
 
-## Choosing an aligner
+| Option | Description | Default | Mode |
+|--------|-------------|---------|------|
+| `-o, --output` | Output file prefix | derived from reads filename | all |
+| `-t, --threads` | Number of threads | `1` | all |
+| `-a, --aligner` | `minimap2` or `bwa` (bwa-mem backend) | `minimap2` | single |
+| `--stop` | Stop after: `index`, `place`, `align`, `genotype`, `consensus` | `consensus` | single |
+| `--force-leaf` | Restrict placement to leaf nodes | off (auto-enabled unless `--stop place`) | single |
+| `--refine` | Alignment-based refinement of top candidates | off | single |
+
+## Choosing an aligner (single-sample only, ignored with `--meta`)
 
 - **minimap2** (default): fast, good for most cases
-- **bwa**: higher sensitivity, may be preferable for short reads
+- **bwa** (`-a bwa`): bwa-mem backend; higher sensitivity, may be preferable for short reads
 
 ```bash
 panmap ref.panman reads.fq -a bwa -o sample
 ```
 
-## Refining placement
+## Refining placement (single-sample only, ignored with `--meta`)
 
 `--refine` uses alignment scores to re-rank placement candidates. Slower but can improve accuracy when seed-based placement is ambiguous.
 
@@ -107,30 +111,33 @@ Refinement parameters:
 
 ## Advanced options
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-i, --index` | Path to pre-built index file | derived from output/panman |
-| `-f, --reindex` | Force rebuild index | off |
-| `--dedup` | Deduplicate reads | off |
-| `--impute` | Impute N's from parent (skip _->N mutations) | off |
-| `--no-mutation-spectrum` | Disable mutation spectrum filtering in VCF genotyping | off |
-| `--baq` | Enable Base Alignment Quality in mpileup | off |
-| `--batch` | Batch file listing samples (one per line: `reads1 [reads2] [output_prefix]`) | -- |
+| Option | Description | Default | Mode |
+|--------|-------------|---------|------|
+| `-i, --index` | Load a pre-built index from this path | derived from the panman (or `--index-out`); never from `-o` | all |
+| `--index-out` | Write the built index to this path | next to the panman | all |
+| `-f, --reindex` | Force rebuild index | off | all |
+| `--dedup` | Deduplicate reads | off | single |
+| `--impute` | Impute N's from parent (skip _->N mutations) | off | all |
+| `--no-mutation-spectrum` | Disable mutation spectrum filtering in VCF genotyping | off | single |
+| `--baq` | Enable Base Alignment Quality in mpileup | off | single |
+| `--batch` | Batch file listing samples (one per line: `reads1 [reads2] [output_prefix]`) | -- | all |
 
-## Seed parameters
+## Seed and read parameters
 
-| Option | Description | Default |
-|--------|-------------|---------|
-| `-k, --kmer` | Syncmer k-mer length | `19` |
-| `-s, --syncmer` | Syncmer s parameter | `8` |
-| `-l, --lmer` | Syncmers per seed | `3` |
-| `--offset` | Syncmer offset | `0` |
-| `--open-syncmer` | Use open syncmers | off |
-| `--hpc` | Homopolymer-compressed seeds | off |
-| `--flank-mask` | Mask bp at ends of genomes | `250` |
-| `--seed-mask-fraction` | Mask top seed fraction | `0` |
-| `--min-seed-quality` | Minimum Phred score for seed region | `0` |
-| `--min-read-support` | Minimum reads for a seed (2 = filter singletons) | `1` |
-| `--trim-start` | Trim bases from read start | `0` |
-| `--trim-end` | Trim bases from read end | `0` |
-| `--extent-guard` | Guard seed deletions at genome extent boundaries | off |
+Index and seeding options (`Mode = all`) shape the index and apply to both single-sample and `--meta` runs. Read-level options (`Mode = single`) are single-sample only and ignored with `--meta`.
+
+| Option | Description | Default | Mode |
+|--------|-------------|---------|------|
+| `-k, --kmer` | Syncmer k-mer length | `19` | all |
+| `-s, --syncmer` | Syncmer s parameter | `8` | all |
+| `-l, --lmer` | Syncmers per seed | `3` | all |
+| `--offset` | Syncmer offset | `0` | all |
+| `--open-syncmer` | Use open syncmers | off | all |
+| `--hpc` | Homopolymer-compressed seeds | off | all |
+| `--flank-mask` | Mask bp at ends of genomes | `250` | all |
+| `--seed-mask-fraction` | Mask top seed fraction | `0` | all |
+| `--extent-guard` | Guard seed deletions at genome extent boundaries | off | all |
+| `--min-seed-quality` | Minimum Phred score for seed region | `0` | single |
+| `--min-read-support` | Min reads for a seed; `-1`=auto (filter singletons when est. coverage >3x), `1`=keep all, `2`=filter singletons | `-1` (auto) | single |
+| `--trim-start` | Trim bases from read start | `0` | single |
+| `--trim-end` | Trim bases from read end | `0` | single |

--- a/examples/wastewater/README.md
+++ b/examples/wastewater/README.md
@@ -17,11 +17,10 @@ python3 ../scripts/trim_and_stack_amplicon.py stack SRR19707934.sorted.bam ../ex
 samtools fastq --no-sc SRR19707934.trimmed.sorted.bam > SRR19707934.trimmed.fastq
 ```
 
-Build an index and run panmap:
+Run panmap in metagenomic mode. It derives and caches the metagenomic index (`sars_20000_twilight_dipper.panman.midx`) next to the PanMAN on first run, so there is no separate build step:
 
 ```bash
-../build/bin/panmap ../examples/data/sars_20000_twilight_dipper.panman --index-mgsr sars_20000_twilight_dipper.idx 
-../build/bin/panmap  ../examples/data/sars_20000_twilight_dipper.panman  SRR19707934.trimmed.fastq --meta --index sars_20000_twilight_dipper.idx --amplicon-depth SRR19707934.amplicon_stacks.tsv --mask-reads-relative-frequency 0.01 em-delta-threshold  0.00001 --output SRR19707934 --threads 8
+../build/bin/panmap ../examples/data/sars_20000_twilight_dipper.panman SRR19707934.trimmed.fastq --meta --amplicon-depth SRR19707934.amplicon_stacks.tsv --mask-reads-relative-frequency 0.01 --em-delta-threshold 0.00001 --output SRR19707934 --threads 8
 ```
 
 Panmap writes per-node abundance estimates to `SRR19707934.mgsr.abundance.out`.
@@ -30,6 +29,6 @@ For lineage proportions, retrieve the sequences from the PanMAN and identify the
 
 ```bash
 ../build/bin/panmap ../examples/data/sars_20000_twilight_dipper.panman --dump-sequences "$(cut -f1 SRR19707934.mgsr.abundance.out | tr ',' '\n' | grep '\S' | tr '\n' ' ' | sed 's/ $//g')" --output SRR19707934
-pangolin pangolin SRR19707934.dump-sequences.fa --outfile SRR19707934.pangolin.csv
+pangolin SRR19707934.dump-sequences.fa --outfile SRR19707934.pangolin.csv
 python3 ../scripts/assign_lineage.py SRR19707934.mgsr.abundance.out SRR19707934.pangolin.csv > SRR19707934.mgsr.lineage.abundance.out
 ```

--- a/src/bwa_align.c
+++ b/src/bwa_align.c
@@ -1,0 +1,226 @@
+// bwa-mem backend for the single-sample alignment stage. Provides
+// bwa_align_reads_direct(), a drop-in twin of align_reads_direct() (mm_align.c)
+// that produces the same aligner-agnostic align_pair_result_t results, so the
+// downstream BAM builder (conversion.cpp) is unchanged. Selected by --aligner bwa.
+
+#include <limits.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "3rdparty/bwa/bntseq.h"
+#include "3rdparty/bwa/bwa.h"
+#include "3rdparty/bwa/bwamem.h"
+
+// Aligner-agnostic result structs, mirrored from mm_align.h. Redeclared (not
+// included) so this TU does not pull in minimap2 headers alongside bwa's.
+// Layout must stay in sync with mm_align.h.
+typedef struct {
+    int32_t pos;  // 1-based ref position (INT_MAX if unmapped); sort key only
+    int32_t rs, re;
+    int32_t qs, qe;
+    uint8_t mapq;
+    uint8_t rev;
+    uint8_t proper_frag;
+    int32_t n_cigar;
+    uint32_t* cigar;  // BAM-encoded; malloc'd, caller frees
+} read_align_t;
+
+typedef struct {
+    read_align_t r1;
+    read_align_t r2;
+    int mapped;
+} align_pair_result_t;
+
+// bwa's internal CIGAR ops are MIDSH => 0,1,2,3,4; htslib/BAM is MIDNSHP=X =>
+// 0..8 (S=4, H=5). Translate op codes; lengths are unchanged.
+static const int BWA_OP_TO_BAM[5] = {0, 1, 2, 4, 5};
+
+// Align one forward read against the loaded index; fill `out`. Returns 1 if mapped.
+static int bwa_align_one(const bwaidx_t* idx, const mem_opt_t* opt, const char* read, int len, read_align_t* out) {
+    memset(out, 0, sizeof(*out));
+    out->pos = INT_MAX;
+    if (len <= 0) return 0;
+
+    uint8_t* seq = (uint8_t*)malloc(len);
+    for (int i = 0; i < len; i++) {
+        int c = (unsigned char)read[i];
+        seq[i] = c < 4 ? c : nst_nt4_table[c];  // ASCII -> 2-bit
+    }
+
+    mem_alnreg_v ar = mem_align1(opt, idx->bwt, idx->bns, idx->pac, len, (char*)seq);
+
+    // Highest-scoring primary region (secondary < 0).
+    int best = -1, best_score = 0;
+    for (size_t i = 0; i < ar.n; i++) {
+        if (ar.a[i].secondary >= 0) continue;
+        if (ar.a[i].score > best_score) {
+            best_score = ar.a[i].score;
+            best = (int)i;
+        }
+    }
+
+    int mapped = 0;
+    if (best >= 0) {
+        mem_aln_t a = mem_reg2aln(opt, idx->bns, idx->pac, len, (char*)seq, &ar.a[best]);
+        // mem_reg2aln already appends soft-clips and gives a.pos as the 0-based
+        // ref position of the first matched base (BAM-ready). Keep its full cigar
+        // and set qs/qe so the BAM builder adds no further clips; just remap ops.
+        if (a.rid >= 0 && a.n_cigar > 0) {
+            uint32_t* cig = (uint32_t*)malloc(a.n_cigar * sizeof(uint32_t));
+            int64_t ref_span = 0;
+            for (int j = 0; j < a.n_cigar; j++) {
+                uint32_t op = a.cigar[j] & 0xf, oplen = a.cigar[j] >> 4;
+                uint32_t bam_op = op < 5 ? (uint32_t)BWA_OP_TO_BAM[op] : op;
+                cig[j] = (oplen << 4) | bam_op;
+                if (bam_op == 0 || bam_op == 2) ref_span += oplen;  // M/D consume ref
+            }
+            out->pos = (int32_t)(a.pos + 1);
+            out->rs = (int32_t)a.pos;
+            out->re = (int32_t)(a.pos + ref_span);
+            out->qs = 0;
+            out->qe = len;
+            out->mapq = a.mapq;
+            out->rev = a.is_rev;
+            out->proper_frag = 0;  // mates aligned independently
+            out->n_cigar = a.n_cigar;
+            out->cigar = cig;
+            mapped = 1;
+        }
+        free(a.cigar);
+    }
+
+    free(ar.a);
+    free(seq);
+    return mapped;
+}
+
+typedef struct {
+    const bwaidx_t* idx;
+    const mem_opt_t* opt;
+    const char** reads;
+    const int* r_lens;
+    align_pair_result_t* results;
+    int paired;
+    int start_pair;
+    int end_pair;
+} bwa_worker_t;
+
+static void* bwa_worker_func(void* arg) {
+    bwa_worker_t* w = (bwa_worker_t*)arg;
+    if (w->paired) {
+        for (int k = w->start_pair; k < w->end_pair; k++) {
+            int i = k * 2;
+            align_pair_result_t* res = &w->results[k];
+            memset(res, 0, sizeof(*res));
+            int m1 = bwa_align_one(w->idx, w->opt, w->reads[i], w->r_lens[i], &res->r1);
+            int m2 = bwa_align_one(w->idx, w->opt, w->reads[i + 1], w->r_lens[i + 1], &res->r2);
+            if (m1 && m2) {
+                res->mapped = 1;
+                // Both mates mapped: flag as a proper pair. bcftools mpileup
+                // discards anomalous pairs by default, so without this the
+                // aligned reads never reach genotyping. (Mates are aligned
+                // independently, so we don't infer insert size/orientation;
+                // R2 is already reverse-complemented upstream.)
+                res->r1.proper_frag = 1;
+                res->r2.proper_frag = 1;
+            } else {
+                // Mirror the minimap2 path: a pair counts only if both mates map.
+                free(res->r1.cigar);
+                free(res->r2.cigar);
+                memset(res, 0, sizeof(*res));
+                res->r1.pos = INT_MAX;
+                res->r2.pos = INT_MAX;
+            }
+        }
+    } else {
+        for (int k = w->start_pair; k < w->end_pair; k++) {
+            align_pair_result_t* res = &w->results[k];
+            memset(res, 0, sizeof(*res));
+            res->mapped = bwa_align_one(w->idx, w->opt, w->reads[k], w->r_lens[k], &res->r1);
+        }
+    }
+    return NULL;
+}
+
+// Same signature as align_reads_direct (mm_align.c). Builds a temporary bwa
+// index for the single reference, aligns reads (mates independently), and
+// fills `results`. Each mapped read's cigar is malloc'd; caller frees.
+void bwa_align_reads_direct(const char* reference,
+                            int n_reads,
+                            const char** reads,
+                            const char** quality,
+                            const char** read_names,
+                            const int* r_lens,
+                            align_pair_result_t* results,
+                            bool pairedEndReads,
+                            int n_threads) {
+    (void)quality;
+    (void)read_names;
+    if (n_reads <= 0 || !reference) return;
+
+    bwa_verbose = 0;  // silence bwa's stderr chatter
+
+    // bwa indexes from disk; write the reference to a unique temp FASTA and
+    // build a throwaway index next to it, then unlink everything once loaded.
+    char tmpl[] = "/tmp/panmap_bwa_XXXXXX";
+    int fd = mkstemp(tmpl);
+    if (fd < 0) return;
+    FILE* fa = fdopen(fd, "w");
+    if (!fa) {
+        close(fd);
+        unlink(tmpl);
+        return;
+    }
+    fprintf(fa, ">ref\n%s\n", reference);
+    fclose(fa);
+
+    int build_rc = bwa_idx_build(tmpl, tmpl, 0 /* BWTALGO_AUTO */, 10000000);
+    bwaidx_t* idx = (build_rc == 0) ? bwa_idx_load(tmpl, BWA_IDX_ALL) : NULL;
+
+    const char* exts[] = {"", ".amb", ".ann", ".bwt", ".pac", ".sa"};
+    char path[4096];
+    for (int e = 0; e < 6; e++) {
+        snprintf(path, sizeof(path), "%s%s", tmpl, exts[e]);
+        unlink(path);
+    }
+    if (!idx) return;
+
+    mem_opt_t* opt = mem_opt_init();  // defaults tuned for short reads
+
+    if (n_threads < 1) n_threads = 1;
+    int n_items = pairedEndReads ? n_reads / 2 : n_reads;
+    if (n_threads > n_items) n_threads = n_items;
+    if (n_threads < 1) n_threads = 1;
+
+    bwa_worker_t* workers = (bwa_worker_t*)malloc(n_threads * sizeof(bwa_worker_t));
+    int chunk = n_items / n_threads, remainder = n_items % n_threads, offset = 0;
+    for (int t = 0; t < n_threads; t++) {
+        workers[t].idx = idx;
+        workers[t].opt = opt;
+        workers[t].reads = reads;
+        workers[t].r_lens = r_lens;
+        workers[t].results = results;
+        workers[t].paired = pairedEndReads ? 1 : 0;
+        workers[t].start_pair = offset;
+        workers[t].end_pair = offset + chunk + (t < remainder ? 1 : 0);
+        offset = workers[t].end_pair;
+    }
+
+    if (n_threads == 1) {
+        bwa_worker_func(&workers[0]);
+    } else {
+        pthread_t* threads = (pthread_t*)malloc(n_threads * sizeof(pthread_t));
+        for (int t = 0; t < n_threads; t++) pthread_create(&threads[t], NULL, bwa_worker_func, &workers[t]);
+        for (int t = 0; t < n_threads; t++) pthread_join(threads[t], NULL);
+        free(threads);
+    }
+
+    free(workers);
+    free(opt);
+    bwa_idx_destroy(idx);
+}

--- a/src/conversion.cpp
+++ b/src/conversion.cpp
@@ -361,6 +361,7 @@ void alignAndWriteBam(std::vector<std::string>& readSequences,
                       const std::string& bamFileName,
                       bool pairedEndReads,
                       int n_threads,
+                      bool useBwa,
                       const std::string& refName) {
     int n_reads = static_cast<int>(readSequences.size());
 
@@ -378,15 +379,16 @@ void alignAndWriteBam(std::vector<std::string>& readSequences,
     int n_results = pairedEndReads ? n_reads / 2 : n_reads;
     std::vector<align_pair_result_t> results(n_results);
 
-    align_reads_direct(reference.c_str(),
-                       n_reads,
-                       read_ptrs.data(),
-                       qual_ptrs.data(),
-                       name_ptrs.data(),
-                       r_lens.data(),
-                       results.data(),
-                       pairedEndReads,
-                       n_threads);
+    auto aligner_fn = useBwa ? bwa_align_reads_direct : align_reads_direct;
+    aligner_fn(reference.c_str(),
+               n_reads,
+               read_ptrs.data(),
+               qual_ptrs.data(),
+               name_ptrs.data(),
+               r_lens.data(),
+               results.data(),
+               pairedEndReads,
+               n_threads);
 
     std::string samHeaderStr =
         "@HD\tVN:1.6\tSO:coordinate\n@SQ\tSN:" + refName + "\tLN:" + std::to_string(reference.length());

--- a/src/conversion.hpp
+++ b/src/conversion.hpp
@@ -40,4 +40,5 @@ void alignAndWriteBam(std::vector<std::string>& readSequences,
                       const std::string& bamFileName,
                       bool pairedEndReads,
                       int n_threads,
+                      bool useBwa = false,
                       const std::string& refName = "ref");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1606,8 +1606,15 @@ int runAlignment(const Config& cfg, const placement::PlacementResult& placement,
 
     // Parallel alignment with direct BAM construction
     bool pairedEndReads = !cfg.reads2.empty();
-    alignAndWriteBam(
-        readSequences, readQuals, readNames, bestMatchSequence, bamFileName, pairedEndReads, cfg.threads, nodeId);
+    alignAndWriteBam(readSequences,
+                     readQuals,
+                     readNames,
+                     bestMatchSequence,
+                     bamFileName,
+                     pairedEndReads,
+                     cfg.threads,
+                     cfg.aligner == "bwa",
+                     nodeId);
 
     auto elapsed =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start);
@@ -1732,43 +1739,55 @@ int main(int argc, char** argv) {
     visible.add_options()("help,h", "Show help (--help-all for more)")("help-all", "Show all options")(
         "version,V", "Show version")("output,o", po::value<std::string>(&cfg.output), "Output prefix")(
         "threads,t", po::value<int>(&cfg.threads)->default_value(1), "Threads")(
-        "stop",
-        po::value<std::string>()->default_value("consensus"),
-        "Stop after: index|place|align|genotype|consensus")(
         "meta", po::bool_switch(&cfg.metagenomic), "Metagenomic mode (for more options, see --help-all)")(
-        "aligner,a", po::value<std::string>(&cfg.aligner)->default_value("minimap2"), "Aligner: minimap2|bwa")(
         "verbose,v", po::bool_switch(&cfg.verbose), "Verbose output")(
-        "quiet,q", po::bool_switch(&cfg.quiet), "Quiet output")("no-color", po::bool_switch(&cfg.plain), "No colors");
+        "quiet,q", po::bool_switch(&cfg.quiet), "Quiet output")("no-color", po::bool_switch(&cfg.plain), "No colors")(
+        "batch",
+        po::value<std::string>(&cfg.batchFile),
+        "Batch file: one sample per line (reads1 [reads2] [output_prefix]); works in both modes");
 
-    po::options_description advanced("Advanced");
-    advanced.add_options()("index,i", po::value<std::string>(&cfg.index), "Load a pre-built index from this path")(
+    // Options that shape the index and seeds. The index is built (or reused) the
+    // same way for single-sample and --meta runs, so these apply to both modes.
+    po::options_description indexOpts("Index & seeding options (both modes)");
+    indexOpts.add_options()("index,i", po::value<std::string>(&cfg.index), "Load a pre-built index from this path")(
         "index-out",
         po::value<std::string>(&cfg.indexOut),
         "Write the built index to this path (default: next to the panman)")(
         "reindex,f", po::bool_switch(&cfg.forceReindex), "Force rebuild index")(
-        "dedup", po::bool_switch(&cfg.dedupReads), "Deduplicate reads")(
-        "impute", po::bool_switch(&cfg.impute), "Impute N's from parent (skip _->N mutations in indexing and output)")(
-        "no-mutation-spectrum",
-        po::bool_switch(&cfg.noMutationSpectrum),
-        "Disable mutation spectrum filtering in VCF genotyping")(
-        "baq", po::bool_switch(&cfg.baq), "Enable BAQ (Base Alignment Quality) in mpileup (default: off)")(
         "kmer,k", po::value<int>(&cfg.k)->default_value(19), "Syncmer k")(
         "syncmer,s", po::value<int>(&cfg.s)->default_value(8), "Syncmer s")(
         "offset", po::value<int>(&cfg.t)->default_value(0), "Syncmer offset")(
         "lmer,l", po::value<int>(&cfg.l)->default_value(3), "Syncmers per seed")(
         "open-syncmer", po::bool_switch(&cfg.openSyncmer), "Open syncmer")(
+        "hpc", po::bool_switch(&cfg.hpc), "Homopolymer-compressed seeds")(
         "flank-mask", po::value<int>(&cfg.flankMaskBp)->default_value(250), "Mask bp at ends")(
         "seed-mask-fraction", po::value<double>(&cfg.seedMaskFraction)->default_value(0), "Mask top seed fraction")(
-        "min-seed-quality", po::value<int>(&cfg.minSeedQuality)->default_value(0), "Min seed quality")(
+        "extent-guard", po::bool_switch(&cfg.extentGuard), "Guard seed deletions at genome extent boundaries")(
+        "impute", po::bool_switch(&cfg.impute), "Impute N's from parent (skip _->N mutations in indexing and output)")(
+        "zstd-level", po::value<int>(&cfg.zstdLevel)->default_value(7), "ZSTD compression level for index (1-22)");
+
+    // The place -> align -> genotype -> consensus pipeline. These are ignored in
+    // --meta mode, which runs its own read-assignment/abundance flow instead.
+    po::options_description singleSample("Single-sample options (default mode; ignored with --meta)");
+    singleSample.add_options()(
+        "stop",
+        po::value<std::string>()->default_value("consensus"),
+        "Stop after: index|place|align|genotype|consensus")(
+        "aligner,a", po::value<std::string>(&cfg.aligner)->default_value("minimap2"), "Aligner: minimap2|bwa")(
+        "dedup", po::bool_switch(&cfg.dedupReads), "Deduplicate reads")(
         "trim-start", po::value<int>(&cfg.trimStart)->default_value(0), "Trim read start")(
         "trim-end", po::value<int>(&cfg.trimEnd)->default_value(0), "Trim read end")(
+        "min-seed-quality", po::value<int>(&cfg.minSeedQuality)->default_value(0), "Min seed quality")(
         "min-read-support",
         po::value<int>(&cfg.minReadSupport)->default_value(-1),
-        "Min reads for a seed; -1=auto (filter singletons only when est. coverage >3x), 1=keep all, 2=filter singletons")("hpc", po::bool_switch(&cfg.hpc), "Homopolymer-compressed seeds")(
-        "extent-guard", po::bool_switch(&cfg.extentGuard), "Guard seed deletions at genome extent boundaries")(
+        "Min reads for a seed; -1=auto (filter singletons only when est. coverage >3x), 1=keep all, 2=filter singletons")(
         "force-leaf",
         po::bool_switch(&cfg.forceLeaf),
         "Restrict placement to leaf nodes only (default unless --stop place)")(
+        "no-mutation-spectrum",
+        po::bool_switch(&cfg.noMutationSpectrum),
+        "Disable mutation spectrum filtering in VCF genotyping")(
+        "baq", po::bool_switch(&cfg.baq), "Enable BAQ (Base Alignment Quality) in mpileup (default: off)")(
         "refine", po::bool_switch(&cfg.refine), "Enable alignment-based refinement")(
         "refine-top-pct",
         po::value<double>(&cfg.refineTopPct)->default_value(0.01),
@@ -1778,13 +1797,9 @@ int main(int argc, char** argv) {
         po::value<int>(&cfg.refineNeighborRadius)->default_value(2),
         "Expand to neighbors within N branches")("refine-max-neighbor-n",
                                                  po::value<int>(&cfg.refineMaxNeighborN)->default_value(150),
-                                                 "Max additional nodes from neighbor expansion")(
-        "zstd-level", po::value<int>(&cfg.zstdLevel)->default_value(7), "ZSTD compression level for index (1-22)")(
-        "batch",
-        po::value<std::string>(&cfg.batchFile),
-        "Batch file listing samples (one per line: reads1 [reads2] [output_prefix]); works in normal and --meta modes");
+                                                 "Max additional nodes from neighbor expansion");
 
-    po::options_description metagenomic("Metagenomic");
+    po::options_description metagenomic("Metagenomic options (require --meta)");
     metagenomic.add_options()(
         "index-packed", po::bool_switch(&cfg.indexPacked), "Build packed capnp message (default false)")(
         "read-packed", po::bool_switch(&cfg.readPacked), "Read packed capnp message (default false)")(
@@ -1891,10 +1906,10 @@ int main(int argc, char** argv) {
     pos.add("panman", 1).add("reads", -1);
 
     po::options_description all;  // For parsing
-    all.add(visible).add(advanced).add(metagenomic).add(em).add(filterAndAssign).add(developer).add(positional);
+    all.add(visible).add(indexOpts).add(singleSample).add(metagenomic).add(em).add(filterAndAssign).add(developer).add(positional);
 
     po::options_description visible_all;  // For --help-all
-    visible_all.add(visible).add(advanced).add(metagenomic).add(em).add(filterAndAssign).add(developer);
+    visible_all.add(visible).add(indexOpts).add(singleSample).add(metagenomic).add(em).add(filterAndAssign).add(developer);
 
     po::variables_map vm;
     try {
@@ -1920,7 +1935,10 @@ int main(int argc, char** argv) {
 
     if (vm.count("help") || argc == 1) {
         printUsage();
-        std::cout << visible << "\n";
+        // Default help shows common + single-sample (the default mode) options;
+        // --help-all adds index/seeding, metagenomic, and developer options.
+        std::cout << visible << "\n" << singleSample << "\n";
+        std::cout << "Run --help-all for index/seeding, metagenomic, and developer options.\n";
         return 0;
     }
 
@@ -1978,6 +1996,11 @@ int main(int argc, char** argv) {
         cfg.stopAfter = PipelineStage::Consensus;
     else {
         output::error("Invalid stage '{}'", stopStr);
+        return 1;
+    }
+
+    if (cfg.aligner != "minimap2" && cfg.aligner != "bwa") {
+        output::error("Invalid aligner '{}' (expected minimap2 or bwa)", cfg.aligner);
         return 1;
     }
 

--- a/src/mm_align.h
+++ b/src/mm_align.h
@@ -50,6 +50,18 @@ void align_reads_direct(const char* reference,
                         bool pairedEndReads,
                         int n_threads);
 
+// bwa-mem backend (bwa_align.c); same contract as align_reads_direct. Selected
+// by --aligner bwa. Builds a temporary bwa index for the single reference.
+void bwa_align_reads_direct(const char* reference,
+                            int n_reads,
+                            const char** reads,
+                            const char** quality,
+                            const char** read_names,
+                            const int* r_lens,
+                            align_pair_result_t* results,
+                            bool pairedEndReads,
+                            int n_threads);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Make `-a bwa` actually work again, clarify which options apply to which mode in both the CLI and docs, fix doc errors.