### PR TITLE
Fix batch race, ignored flags, error propagation

### DIFF
--- a/src/bwa_align.c
+++ b/src/bwa_align.c
@@ -215,8 +215,18 @@ void bwa_align_reads_direct(const char* reference,
         bwa_worker_func(&workers[0]);
     } else {
         pthread_t* threads = (pthread_t*)malloc(n_threads * sizeof(pthread_t));
-        for (int t = 0; t < n_threads; t++) pthread_create(&threads[t], NULL, bwa_worker_func, &workers[t]);
-        for (int t = 0; t < n_threads; t++) pthread_join(threads[t], NULL);
+        char* created = (char*)calloc(n_threads, 1);
+        for (int t = 0; t < n_threads; t++) {
+            // On spawn failure run the chunk synchronously so no reads are dropped,
+            // and don't join an uninitialized thread id.
+            if (pthread_create(&threads[t], NULL, bwa_worker_func, &workers[t]) == 0)
+                created[t] = 1;
+            else
+                bwa_worker_func(&workers[t]);
+        }
+        for (int t = 0; t < n_threads; t++)
+            if (created[t]) pthread_join(threads[t], NULL);
+        free(created);
         free(threads);
     }
 

--- a/src/conversion.cpp
+++ b/src/conversion.cpp
@@ -74,13 +74,13 @@ static int run_bcftools_in_fork(int (*func)(int, char**), int argc, char** argv,
     }
 }
 
-void createMplpBcf(const std::string& prefix,
-                   const std::string& refFileName,
-                   const std::string& bestMatchSequence,
-                   const std::string& bamFileName,
-                   std::string& mpileupFileName,
-                   bool baq,
-                   const std::string& refName) {
+int createMplpBcf(const std::string& prefix,
+                  const std::string& refFileName,
+                  const std::string& bestMatchSequence,
+                  const std::string& bamFileName,
+                  std::string& mpileupFileName,
+                  bool baq,
+                  const std::string& refName) {
     std::string outRefFileName = "";
     if (refFileName.size() == 0) {
         outRefFileName = prefix + ".tmp.reference.fa";
@@ -116,14 +116,15 @@ void createMplpBcf(const std::string& prefix,
     }
     if (rc != 0) {
         output::error("bcftools mpileup failed (exit code {}) for {}", rc, bamFileName);
-        std::exit(1);
+        return 1;
     }
+    return 0;
 }
 
-void createVcfWithMutationMatrices(std::string& prefix,
-                                   std::string& mpileupFileName,
-                                   std::string& vcfFileName,
-                                   const std::vector<std::vector<double>>& substMatrixPhred) {
+int createVcfWithMutationMatrices(std::string& prefix,
+                                  std::string& mpileupFileName,
+                                  std::string& vcfFileName,
+                                  const std::vector<std::vector<double>>& substMatrixPhred) {
     if (mpileupFileName.size() == 0) {
         mpileupFileName = prefix + ".mpileup";
     }
@@ -136,7 +137,7 @@ void createVcfWithMutationMatrices(std::string& prefix,
         int rc = run_bcftools_in_fork(main_vcfcall, 10, const_cast<char**>(call_args));
         if (rc != 0) {
             output::error("bcftools call failed (exit code {})", rc);
-            std::exit(1);
+            return 1;
         }
     }
 
@@ -166,6 +167,7 @@ void createVcfWithMutationMatrices(std::string& prefix,
     }
     rawVcfIn.close();
     std::remove(rawVcfFile.c_str());
+    return 0;
 }
 
 int createConsensus(const std::string& vcfFileName,
@@ -364,14 +366,14 @@ static bam1_t* build_bam_from_result(const std::string& qname_full,
     return b;
 }
 
-void alignAndWriteBam(std::vector<std::string>& readSequences,
-                      std::vector<std::string>& readQuals,
-                      std::vector<std::string>& readNames,
-                      std::string& reference,
-                      const std::string& bamFileName,
-                      bool pairedEndReads,
-                      int n_threads,
-                      bool useBwa,
+int alignAndWriteBam(std::vector<std::string>& readSequences,
+                     std::vector<std::string>& readQuals,
+                     std::vector<std::string>& readNames,
+                     std::string& reference,
+                     const std::string& bamFileName,
+                     bool pairedEndReads,
+                     int n_threads,
+                     bool useBwa,
                       const std::string& refName) {
     int n_reads = static_cast<int>(readSequences.size());
 
@@ -473,20 +475,29 @@ void alignAndWriteBam(std::vector<std::string>& readSequences,
 
     std::sort(bam_entries.begin(), bam_entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
 
+    int rc = 0;
     if (!bamFileName.empty()) {
         htsFile* bam_file = hts_open(bamFileName.c_str(), "wb");
         if (bam_file) {
-            sam_hdr_write(bam_file, header);
+            if (sam_hdr_write(bam_file, header) < 0) rc = 1;
             for (auto& [pos, rec] : bam_entries) {
-                bam_write1(bam_file->fp.bgzf, rec);
+                if (bam_write1(bam_file->fp.bgzf, rec) < 0) {
+                    rc = 1;
+                    break;
+                }
             }
-            hts_close(bam_file);
-            logging::info("Wrote bam files to {}", bamFileName);
-            if (sam_index_build(bamFileName.c_str(), 0) != 0) {
-                logging::warn("Failed to index BAM file: {}", bamFileName);
+            if (hts_close(bam_file) < 0) rc = 1;  // flushes buffered records; a full disk surfaces here
+            if (rc != 0) {
+                logging::err("Failed to write BAM file: {}", bamFileName);
+            } else {
+                logging::info("Wrote bam files to {}", bamFileName);
+                if (sam_index_build(bamFileName.c_str(), 0) != 0) {
+                    logging::warn("Failed to index BAM file: {}", bamFileName);
+                }
             }
         } else {
             logging::err("Failed to open output BAM file: {}", bamFileName);
+            rc = 1;
         }
     }
 
@@ -498,4 +509,5 @@ void alignAndWriteBam(std::vector<std::string>& readSequences,
         free(results[k].r1.cigar);
         free(results[k].r2.cigar);
     }
+    return rc;
 }

--- a/src/conversion.hpp
+++ b/src/conversion.hpp
@@ -13,27 +13,30 @@ namespace genotyping {
 struct mutationMatrices;
 }
 
-void createMplpBcf(const std::string& prefix,
-                   const std::string& refFileName,
-                   const std::string& bestMatchSequence,
-                   const std::string& bamFileName,
-                   std::string& mpileupFileName,
-                   bool baq = false,
-                   const std::string& refName = "ref");
+// Returns 0 on success, non-zero if bcftools mpileup fails.
+int createMplpBcf(const std::string& prefix,
+                  const std::string& refFileName,
+                  const std::string& bestMatchSequence,
+                  const std::string& bamFileName,
+                  std::string& mpileupFileName,
+                  bool baq = false,
+                  const std::string& refName = "ref");
 
-void createVcfWithMutationMatrices(std::string& prefix,
-                                   std::string& mpileupFileName,
-                                   std::string& vcfFileName,
-                                   const std::vector<std::vector<double>>& substMatrixPhred);
+// Returns 0 on success, non-zero if bcftools call fails.
+int createVcfWithMutationMatrices(std::string& prefix,
+                                  std::string& mpileupFileName,
+                                  std::string& vcfFileName,
+                                  const std::vector<std::vector<double>>& substMatrixPhred);
 
 int createConsensus(const std::string& vcfFileName,
                     const std::string& refFileName,
                     const std::string& consensusFileName,
                     const std::string& consensusHeader = "");
 
-// Parallel minimap2 alignment with direct bam1_t construction (no SAM text
-// intermediate). Writes sorted BAM file.
-void alignAndWriteBam(std::vector<std::string>& readSequences,
+// Parallel minimap2/bwa alignment with direct bam1_t construction (no SAM text
+// intermediate). Writes a sorted BAM file. Returns 0 on success, non-zero on a
+// BAM write/close error.
+int alignAndWriteBam(std::vector<std::string>& readSequences,
                       std::vector<std::string>& readQuals,
                       std::vector<std::string>& readNames,
                       std::string& reference,

--- a/src/index_single_mode.cpp
+++ b/src/index_single_mode.cpp
@@ -361,8 +361,12 @@ std::vector<panmapUtils::NewSyncmerRange> index_single_mode::IndexBuilder::compu
                     recomputeBlock = false;
                     recomputeInProgress = false;
                     if (curCoordGapMapIt != gapMap.end()) {
+                        // At begin() there is no previous run, so the lower bound
+                        // (prev->second < curCoordScalar) is vacuously satisfied;
+                        // guard the std::prev to avoid dereferencing before begin().
                         while (curCoordGapMapIt != gapMap.end() &&
-                               !((std::prev(curCoordGapMapIt)->second < curCoordScalar) &&
+                               !((curCoordGapMapIt == gapMap.begin() ||
+                                  std::prev(curCoordGapMapIt)->second < curCoordScalar) &&
                                  (curCoordScalar < curCoordGapMapIt->first))) {
                             ++curCoordGapMapIt;
                         }
@@ -1374,9 +1378,13 @@ void index_single_mode::IndexBuilder::computeSubstitutionSpectrum() {
         for (const auto& blockMut : node->blockMutation) {
             uint32_t blockId = blockMut.primaryBlockId;
             bool oldExists = blockSequences.blockExists[blockId];
-            bool isInsertion = blockMut.blockMutInfo;
             blockUndoRecord.emplace_back(blockId, oldExists);
-            blockSequences.blockExists[blockId] = isInsertion;
+            // blockMutInfo=false marks BOTH deletions and strand inversions; only a
+            // deletion (non-inversion) removes the block. An inverted block still
+            // exists, so its substitutions must keep being counted.
+            if (!blockMut.inversion) {
+                blockSequences.blockExists[blockId] = blockMut.blockMutInfo;
+            }
         }
 
         if (node != T->root) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -373,8 +373,16 @@ bool buildIndex(const Config& cfg) {
         return false;
     }
 
-    index_single_mode::IndexBuilder builder(
-        &tg->trees[0], cfg.k, cfg.s, 0, cfg.l, false, cfg.flankMaskBp, cfg.hpc, cfg.impute, cfg.extentGuard);
+    index_single_mode::IndexBuilder builder(&tg->trees[0],
+                                            cfg.k,
+                                            cfg.s,
+                                            cfg.t,
+                                            cfg.l,
+                                            cfg.openSyncmer,
+                                            cfg.flankMaskBp,
+                                            cfg.hpc,
+                                            cfg.impute,
+                                            cfg.extentGuard);
     builder.buildIndexParallel(cfg.threads);
     builder.computeSubstitutionSpectrum();
     builder.writeIndex(cfg.index, cfg.threads, cfg.zstdLevel);
@@ -1480,7 +1488,8 @@ std::optional<placement::PlacementResult> runPlacement(const Config& cfg) {
     placement::PlacementResult result;
     std::string outPath = cfg.output + ".placement.tsv";
 
-    bool storeDiagnostics = false;
+    // --dump-all-scores needs the per-node seed scores retained after placement.
+    bool storeDiagnostics = !cfg.dumpAllScores.empty();
 
     // Load full tree if refinement is enabled (needed for genome sequences)
     std::unique_ptr<panmanUtils::TreeGroup> tg;
@@ -1522,18 +1531,21 @@ std::optional<placement::PlacementResult> runPlacement(const Config& cfg) {
         std::ofstream outFile(cfg.dumpAllScores);
         if (outFile) {
             outFile << "node\tlogRaw\tlogCosine\tcontainment\tlogContainment\n";
+            // Scores live in the per-call result (metric order 0=logRaw, 1=logCosine,
+            // 2=containment, 3=weightedContainment, 4=logContainment), indexed by node DFS index.
             std::vector<std::pair<double, std::string>> allScores;
             for (auto& [id, node] : tree.allLiteNodes) {
-                if (node->logRawScore > 0 || node->logCosineScore > 0 ||
-                    node->containmentScore > 0 || node->logContainmentScore > 0) {
-                    allScores.push_back({node->logRawScore, id});
+                if (!node || node->nodeIndex >= result.nodeScores.size()) continue;
+                const auto& s = result.nodeScores[node->nodeIndex];
+                if (s[0] > 0 || s[1] > 0 || s[2] > 0 || s[4] > 0) {
+                    allScores.push_back({s[0], id});
                 }
             }
             std::sort(allScores.begin(), allScores.end(), std::greater<>());
             for (auto& [score, id] : allScores) {
                 auto* node = tree.allLiteNodes[id];
-                outFile << id << "\t" << node->logRawScore << "\t" << node->logCosineScore << "\t"
-                        << node->containmentScore << "\t" << node->logContainmentScore << "\n";
+                const auto& s = result.nodeScores[node->nodeIndex];
+                outFile << id << "\t" << s[0] << "\t" << s[1] << "\t" << s[2] << "\t" << s[4] << "\n";
             }
             logging::msg("Dumped {} node scores to {}", allScores.size(), cfg.dumpAllScores);
         } else {
@@ -1607,15 +1619,18 @@ int runAlignment(const Config& cfg, const placement::PlacementResult& placement,
 
     // Parallel alignment with direct BAM construction
     bool pairedEndReads = !cfg.reads2.empty();
-    alignAndWriteBam(readSequences,
-                     readQuals,
-                     readNames,
-                     bestMatchSequence,
-                     bamFileName,
-                     pairedEndReads,
-                     cfg.threads,
-                     cfg.aligner == "bwa",
-                     nodeId);
+    if (alignAndWriteBam(readSequences,
+                         readQuals,
+                         readNames,
+                         bestMatchSequence,
+                         bamFileName,
+                         pairedEndReads,
+                         cfg.threads,
+                         cfg.aligner == "bwa",
+                         nodeId) != 0) {
+        logging::err("Alignment/BAM write failed for {}", bamFileName);
+        return 1;
+    }
 
     auto elapsed =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start);
@@ -1647,8 +1662,12 @@ int runGenotyping(const Config& cfg) {
 
     auto start = std::chrono::high_resolution_clock::now();
 
-    createMplpBcf(prefix, refFileName, bestMatchSequence, bamFileName, mpileupFileName, cfg.baq, refName);
-    createVcfWithMutationMatrices(prefix, mpileupFileName, vcfFileName, cfg.substMatrixPhred);
+    if (createMplpBcf(prefix, refFileName, bestMatchSequence, bamFileName, mpileupFileName, cfg.baq, refName) != 0) {
+        return 1;
+    }
+    if (createVcfWithMutationMatrices(prefix, mpileupFileName, vcfFileName, cfg.substMatrixPhred) != 0) {
+        return 1;
+    }
 
     auto elapsed =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - start);
@@ -2002,6 +2021,17 @@ int main(int argc, char** argv) {
 
     if (cfg.aligner != "minimap2" && cfg.aligner != "bwa") {
         output::error("Invalid aligner '{}' (expected minimap2 or bwa)", cfg.aligner);
+        return 1;
+    }
+
+    // Syncmer parameters must satisfy 0 < s <= k and 0 <= offset <= k-s; otherwise
+    // the s-mer window / offset index the rolling-syncmer deque out of bounds.
+    if (cfg.s <= 0 || cfg.s > cfg.k) {
+        output::error("Invalid syncmer s={} (must be in 1..k, k={})", cfg.s, cfg.k);
+        return 1;
+    }
+    if (cfg.t < 0 || cfg.t > cfg.k - cfg.s) {
+        output::error("Invalid syncmer offset={} (must be in 0..k-s = 0..{})", cfg.t, cfg.k - cfg.s);
         return 1;
     }
 

--- a/src/mm_align.c
+++ b/src/mm_align.c
@@ -325,8 +325,19 @@ void align_reads_direct(const char* reference,
         align_worker_func(&workers[0]);
     } else {
         pthread_t* threads = (pthread_t*)malloc(n_threads * sizeof(pthread_t));
-        for (int t = 0; t < n_threads; t++) pthread_create(&threads[t], NULL, align_worker_func, &workers[t]);
-        for (int t = 0; t < n_threads; t++) pthread_join(threads[t], NULL);
+        char* created = (char*)calloc(n_threads, 1);
+        for (int t = 0; t < n_threads; t++) {
+            // If a thread can't be spawned (e.g. RLIMIT_NPROC/ENOMEM), run its
+            // chunk synchronously so no reads are silently dropped, and don't
+            // join an uninitialized thread id.
+            if (pthread_create(&threads[t], NULL, align_worker_func, &workers[t]) == 0)
+                created[t] = 1;
+            else
+                align_worker_func(&workers[t]);
+        }
+        for (int t = 0; t < n_threads; t++)
+            if (created[t]) pthread_join(threads[t], NULL);
+        free(created);
         free(threads);
     }
 

--- a/src/panmap_utils.hpp
+++ b/src/panmap_utils.hpp
@@ -53,13 +53,6 @@ class LiteNode {
 
     // Seed changes from parent to this node (hash, parentCount, childCount)
     std::span<const std::tuple<uint64_t, int64_t, int64_t>> seedChanges;
-
-    // Placement scores, populated during placement
-    float logRawScore = 0.0f;
-    float logCosineScore = 0.0f;
-    float containmentScore = 0.0f;
-    float weightedContainmentScore = 0.0f;
-    float logContainmentScore = 0.0f;
 };
 
 class LiteTree {

--- a/src/pileup.c
+++ b/src/pileup.c
@@ -429,6 +429,7 @@ int our_mpileup(mplp_conf_t* conf, sam_hdr_t* sam_header, kstring_t* mplp_string
                                            conf->no_del,
                                            conf->no_ends) < 0) {
                             ret = 1;
+                            ks_free(&ks);  // fail path skips the normal ks_free below
                             goto fail;
                         }
                     }

--- a/src/placement.cpp
+++ b/src/placement.cpp
@@ -262,13 +262,13 @@ using ::panmanUtils::Node;
 using ::panmanUtils::Tree;
 
 
-// Generates a score update function: stores score on node, updates best score/index, tracks ties.
-#define DEFINE_UPDATE_SCORE_FUNC(FuncName, nodeScoreField, bestScore, bestNodeIndex, tiedIndices)   \
-    void PlacementResult::FuncName(uint32_t nodeIndex, double score, panmapUtils::LiteNode* node) { \
-        if (node) {                                                                                 \
-            node->nodeScoreField = static_cast<float>(score);                                       \
-        }                                                                                           \
-        double tolerance = std::max(bestScore * 0.0001, 1e-9);                                      \
+// Generates a score update function: updates best score/index and tracks ties.
+// Per-node scores are stored separately in PlacementResult::nodeScores (see the
+// BFS scoring block), not on the shared LiteNode, so concurrent batch placements
+// don't race.
+#define DEFINE_UPDATE_SCORE_FUNC(FuncName, nodeScoreField, bestScore, bestNodeIndex, tiedIndices) \
+    void PlacementResult::FuncName(uint32_t nodeIndex, double score) {                            \
+        double tolerance = std::max(bestScore * 0.0001, 1e-9);                                    \
         if (score > bestScore + tolerance) {                                                        \
             bestScore = score;                                                                      \
             bestNodeIndex = nodeIndex;                                                              \
@@ -471,11 +471,16 @@ void refineTopCandidates(panmapUtils::LiteTree* liteTree,
         return metricCandidates;
     };
 
-    auto logRawCands = getTopForMetric([](auto* n) { return n->logRawScore; }, "LogRaw");
-    auto logCosineCands = getTopForMetric([](auto* n) { return n->logCosineScore; }, "LogCosine");
-    auto containCands = getTopForMetric([](auto* n) { return n->containmentScore; }, "Containment");
-    auto wContainCands = getTopForMetric([](auto* n) { return n->weightedContainmentScore; }, "WeightedContainment");
-    auto logContainCands = getTopForMetric([](auto* n) { return n->logContainmentScore; }, "LogContainment");
+    // Read per-node seed scores from the per-call store (metric order:
+    // 0=logRaw, 1=logCosine, 2=containment, 3=weightedContainment, 4=logContainment).
+    auto nodeScore = [&](panmapUtils::LiteNode* n, int metric) -> float {
+        return n && n->nodeIndex < result.nodeScores.size() ? result.nodeScores[n->nodeIndex][metric] : 0.0f;
+    };
+    auto logRawCands = getTopForMetric([&](auto* n) { return nodeScore(n, 0); }, "LogRaw");
+    auto logCosineCands = getTopForMetric([&](auto* n) { return nodeScore(n, 1); }, "LogCosine");
+    auto containCands = getTopForMetric([&](auto* n) { return nodeScore(n, 2); }, "Containment");
+    auto wContainCands = getTopForMetric([&](auto* n) { return nodeScore(n, 3); }, "WeightedContainment");
+    auto logContainCands = getTopForMetric([&](auto* n) { return nodeScore(n, 4); }, "LogContainment");
 
     // Always include the unrefined best node for each metric in its candidate set.
     // At high coverage, seed scores saturate and the correct node may fall outside
@@ -576,11 +581,11 @@ void refineTopCandidates(panmapUtils::LiteTree* liteTree,
         return {bestScore, bestIdx};
     };
 
-    auto [lrScore, lrIdx] = findBestForMetric(logRawExpanded, [](auto* n) { return n->logRawScore; });
-    auto [lcScore, lcIdx] = findBestForMetric(logCosineExpanded, [](auto* n) { return n->logCosineScore; });
-    auto [cScore, cIdx] = findBestForMetric(containExpanded, [](auto* n) { return n->containmentScore; });
-    auto [wcScore, wcIdx] = findBestForMetric(wContainExpanded, [](auto* n) { return n->weightedContainmentScore; });
-    auto [lgcScore, lgcIdx] = findBestForMetric(logContainExpanded, [](auto* n) { return n->logContainmentScore; });
+    auto [lrScore, lrIdx] = findBestForMetric(logRawExpanded, [&](auto* n) { return nodeScore(n, 0); });
+    auto [lcScore, lcIdx] = findBestForMetric(logCosineExpanded, [&](auto* n) { return nodeScore(n, 1); });
+    auto [cScore, cIdx] = findBestForMetric(containExpanded, [&](auto* n) { return nodeScore(n, 2); });
+    auto [wcScore, wcIdx] = findBestForMetric(wContainExpanded, [&](auto* n) { return nodeScore(n, 3); });
+    auto [lgcScore, lgcIdx] = findBestForMetric(logContainExpanded, [&](auto* n) { return nodeScore(n, 4); });
 
     if (lrIdx != UINT32_MAX) {
         result.refinedLogRaw = {static_cast<double>(lrScore), lrIdx, ""};
@@ -712,12 +717,23 @@ void placeLiteHelperBFS(std::vector<panmapUtils::LiteNode*>& nodes,
                         double logContainmentScore =
                             nodeMetrics.getLogContainmentScore(state.logContainmentDenominator);
 
-                        // Update thread-local results (no locks)
-                        tls.local_result.updateLogRawScore(nodeIndex, logRawScore, node);
-                        tls.local_result.updateLogCosineScore(nodeIndex, logCosineScore, node);
-                        tls.local_result.updateContainmentScore(nodeIndex, containmentScore, node);
-                        tls.local_result.updateWeightedContainmentScore(nodeIndex, weightedContainmentScore, node);
-                        tls.local_result.updateLogContainmentScore(nodeIndex, logContainmentScore, node);
+                        // Update thread-local best/tie tracking (no locks).
+                        tls.local_result.updateLogRawScore(nodeIndex, logRawScore);
+                        tls.local_result.updateLogCosineScore(nodeIndex, logCosineScore);
+                        tls.local_result.updateContainmentScore(nodeIndex, containmentScore);
+                        tls.local_result.updateWeightedContainmentScore(nodeIndex, weightedContainmentScore);
+                        tls.local_result.updateLogContainmentScore(nodeIndex, logContainmentScore);
+
+                        // Per-node scores for refinement candidate selection. Written to the
+                        // shared per-call result (not the tree) so concurrent batch placements
+                        // don't race; each node index is written by exactly one thread.
+                        if (nodeIndex < result.nodeScores.size()) {
+                            result.nodeScores[nodeIndex] = {static_cast<float>(logRawScore),
+                                                            static_cast<float>(logCosineScore),
+                                                            static_cast<float>(containmentScore),
+                                                            static_cast<float>(weightedContainmentScore),
+                                                            static_cast<float>(logContainmentScore)};
+                        }
                     }
 
                     if (!node->children.empty()) {
@@ -1807,6 +1823,13 @@ void placeLite(PlacementResult& result,
         root_level_metrics.push_back(rootMetrics);
         if (params.verify_scores) {
             root_level_seed_counts.emplace_back();
+        }
+
+        // Refinement (and --dump-all-scores) read per-node seed scores back;
+        // allocate the per-call store (indexed by node DFS index) so the BFS can
+        // fill it without touching the shared tree. Skipped when nothing reads it.
+        if (params.refineEnabled || params.store_diagnostics) {
+            result.nodeScores.assign(liteTree->dfsIndexToNode.size(), {});
         }
 
         std::atomic<size_t> nodesProcessed(0);

--- a/src/placement.hpp
+++ b/src/placement.hpp
@@ -7,6 +7,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cmath>
@@ -170,6 +171,12 @@ struct PlacementResult {
     uint32_t bestLogContainmentNodeIndex = UINT32_MAX;
     std::vector<uint32_t> tiedLogContainmentNodeIndices;
 
+    // Per-call, per-node seed scores indexed by node DFS index (only populated
+    // when refinement is enabled, which is the sole reader). Kept here rather than
+    // on the shared LiteNode so concurrent batch placements don't race. Metric
+    // order: {logRaw, logCosine, containment, weightedContainment, logContainment}.
+    std::vector<std::array<float, 5>> nodeScores;
+
     // Per-metric alignment-based refinement: each metric's top candidates refined independently by full alignment
     struct RefinedResult {
         double score = 0.0;
@@ -187,11 +194,11 @@ struct PlacementResult {
     int64_t totalReadsProcessed = 0;
 
     // Take nodeIndex, resolve to string at end
-    void updateLogRawScore(uint32_t nodeIndex, double score, panmapUtils::LiteNode* node = nullptr);
-    void updateLogCosineScore(uint32_t nodeIndex, double score, panmapUtils::LiteNode* node = nullptr);
-    void updateContainmentScore(uint32_t nodeIndex, double score, panmapUtils::LiteNode* node = nullptr);
-    void updateWeightedContainmentScore(uint32_t nodeIndex, double score, panmapUtils::LiteNode* node = nullptr);
-    void updateLogContainmentScore(uint32_t nodeIndex, double score, panmapUtils::LiteNode* node = nullptr);
+    void updateLogRawScore(uint32_t nodeIndex, double score);
+    void updateLogCosineScore(uint32_t nodeIndex, double score);
+    void updateContainmentScore(uint32_t nodeIndex, double score);
+    void updateWeightedContainmentScore(uint32_t nodeIndex, double score);
+    void updateLogContainmentScore(uint32_t nodeIndex, double score);
 
     // Lazy resolution: convert winning node indices to string IDs (called ONCE at end)
     void resolveNodeIds(panmapUtils::LiteTree* liteTree);


### PR DESCRIPTION
Moved per-node scores to a per-call `PlacementResult::nodeScores`.

Fixes ignored `--offset` / `--open-syncmer`.

Handle bcftools failure.
