### PR TITLE
index: widen nodeChangeOffsets to 64-bit for large pangenomes

### DIFF
--- a/src/index_lite.capnp
+++ b/src/index_lite.capnp
@@ -45,7 +45,7 @@ struct LiteIndex {
   seedChangeHashes @6 :List(List(UInt64));
   seedChangeParentCounts @7 :List(List(Int16));
   seedChangeChildCounts @8 :List(List(Int16));
-  nodeChangeOffsets @9 :List(UInt32);  # Size = numNodes + 1
+  nodeChangeOffsets @9 :List(UInt64);  # Size = numNodes + 1
 
 
   # Homopolymer compression mode: if true, seeds were extracted from HPC sequences
@@ -63,4 +63,8 @@ struct LiteIndex {
 
   # 4x4 nucleotide substitution rate matrix (A=0,C=1,G=2,T=3), row-major
   substitutionMatrix @16 :List(Float64);
+
+  # On-disk format version (see panmapUtils::INDEX_FORMAT_VERSION). Absent (=0) in
+  # pre-versioning indexes so the reader can reject them with a rebuild message.
+  formatVersion @17 :UInt16;
 }

--- a/src/index_single_mode.hpp
+++ b/src/index_single_mode.hpp
@@ -182,6 +182,7 @@ class IndexBuilder {
         indexBuilder.setL(l);
         indexBuilder.setOpen(openSyncmer);
         indexBuilder.setHpc(hpc);
+        indexBuilder.setFormatVersion(panmapUtils::INDEX_FORMAT_VERSION);
         nodeToDfsIndex.reserve(T->allNodes.size());
         nodeSeedCounts.resize(T->allNodes.size());
     }

--- a/src/panmap_utils.hpp
+++ b/src/panmap_utils.hpp
@@ -21,6 +21,14 @@
 
 namespace panmapUtils {
 
+// On-disk index format revision. Bump on any wire-incompatible change to
+// index_lite.capnp (e.g. widening a field's type). The placement reader rejects
+// an index whose version differs, so a stale .idx fails with a clear "rebuild"
+// message instead of a cryptic Cap'n Proto error. Pre-versioning indexes lack
+// the field and read as 0.
+//   4: struct-of-arrays seed changes with 64-bit nodeChangeOffsets
+inline constexpr uint16_t INDEX_FORMAT_VERSION = 4;
+
 enum seedChangeType { ADD, DEL, SUB };
 
 void getSequenceFromReference(panmanUtils::Tree* tree,

--- a/src/placement.cpp
+++ b/src/placement.cpp
@@ -891,6 +891,17 @@ void placeLite(PlacementResult& result,
 
     auto indexRoot = liteIndex.getRoot<LiteIndex>();
 
+    // Reject a stale index before reading any width-sensitive field (the
+    // nodeChangeOffsets element width changed with the format), so an old .idx
+    // fails with a clear rebuild message instead of a cryptic capnp error.
+    if (indexRoot.getFormatVersion() != panmapUtils::INDEX_FORMAT_VERSION) {
+        throw std::runtime_error(fmt::format(
+            "Index format version {} is incompatible with this panmap (expects {}). "
+            "Rebuild the index (delete the .idx and rerun).",
+            indexRoot.getFormatVersion(),
+            panmapUtils::INDEX_FORMAT_VERSION));
+    }
+
     if (!liteTree->seedChangesLoaded) {
         logging::debug("Loading pre-computed hash deltas from index for {} nodes...", liteTree->allLiteNodes.size());
 

--- a/src/test/helpers/test_index.hpp
+++ b/src/test/helpers/test_index.hpp
@@ -30,7 +30,7 @@ class IndexData {
     std::vector<uint64_t> hashes;
     std::vector<int64_t> parentCounts;
     std::vector<int64_t> childCounts;
-    std::vector<uint32_t> offsets;  // size == numNodes + 1
+    std::vector<uint64_t> offsets;  // size == numNodes + 1
 
     size_t numNodesPlusOne() const { return offsets.size(); }
 
@@ -42,7 +42,7 @@ class IndexData {
 
     int64_t childCountAt(size_t i) const { return childCounts[i]; }
 
-    uint32_t nodeChangeOffset(size_t node) const { return offsets[node]; }
+    uint64_t nodeChangeOffset(size_t node) const { return offsets[node]; }
 };
 
 // Decompress + parse an existing .idx, returning an owned IndexData.


### PR DESCRIPTION
Change cumulative seed-change offset (`nodeChangeOffsets`) to `UInt64` to support big panmans like sars_8M.