### PR TITLE
Add release workflow (bump version + GitHub release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+# Manually-triggered release: bump the version and cut a GitHub release.
+#
+# The bioconda recipe is NOT updated here. Bioconda's autobump bot recognizes
+# panmap's GitHub archive URL and opens an "Update panmap to X" PR on its own
+# (usually within a few hours). You're listed in the recipe's recipe-maintainers,
+# so you'll be @-mentioned on that PR; comment `@BiocondaBot please add label`
+# to send it to the review queue. (Autobump does not track dependency changes,
+# so if a release changes deps, verify/adjust the recipe on that PR.)
+#
+# No secrets required: pushing the bump + creating the release use GITHUB_TOKEN.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version, X.Y.Z (no leading v)"
+        required: true
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write   # push the bump commit + create the release
+
+jobs:
+  release:
+    name: Bump + release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version input
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::version must be X.Y.Z (got '$VERSION')"; exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fail if tag already exists
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::tag v${VERSION} already exists"; exit 1
+          fi
+
+      - name: Bump version and push to main
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          bash scripts/bump_version.sh "$VERSION"
+          # Tolerate a no-op bump so a re-run after a partial failure (main already
+          # bumped but never tagged) can still reach the release step.
+          if git diff --quiet; then
+            echo "Working tree already at v${VERSION}; skipping bump commit"
+          else
+            git commit -am "Release v${VERSION}"
+            git push origin HEAD:main
+          fi
+          echo "RELEASE_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "panmap ${VERSION}" \
+            --generate-notes \
+            --target "${RELEASE_SHA}"


### PR DESCRIPTION
Adds `.github/workflows/release.yml` to bumps the version and create a GitHub release. Bioconda auto-updates based on the new release.