### PR TITLE
build: enable ccache, dedup mm_align.c, parallelize minimap2 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,10 +515,18 @@ if(USE_SYSTEM_LIBS AND DEFINED ENV{CONDA_PREFIX})
 else()
     set(_mm2_env "")
 endif()
+# minimap2 has its own Makefile invoked as a nested make. Without a job count it inherits
+# the parent's job-server FDs it can't use (falls back to -j1 with two warnings); unset
+# MAKEFLAGS and give it an explicit -j so it builds in parallel and stays quiet.
+include(ProcessorCount)
+ProcessorCount(NPROC)
+if(NPROC EQUAL 0)
+    set(NPROC 4)
+endif()
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lib/libminimap2.a
-    COMMAND ${CMAKE_COMMAND} -E env ${_mm2_env} make -C ${CMAKE_CURRENT_SOURCE_DIR}/src/3rdparty/minimap2 clean
-    COMMAND ${CMAKE_COMMAND} -E env ${_mm2_env} make -C ${CMAKE_CURRENT_SOURCE_DIR}/src/3rdparty/minimap2 -j ${MINIMAP2_MAKE_ARGS}
+    COMMAND ${CMAKE_COMMAND} -E env --unset=MAKEFLAGS ${_mm2_env} make -C ${CMAKE_CURRENT_SOURCE_DIR}/src/3rdparty/minimap2 clean
+    COMMAND ${CMAKE_COMMAND} -E env --unset=MAKEFLAGS ${_mm2_env} make -C ${CMAKE_CURRENT_SOURCE_DIR}/src/3rdparty/minimap2 -j${NPROC} ${MINIMAP2_MAKE_ARGS}
     COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/lib ${CMAKE_CURRENT_BINARY_DIR}/bin
     COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/src/3rdparty/minimap2/libminimap2.a ${CMAKE_CURRENT_BINARY_DIR}/lib/libminimap2.a
     COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/src/3rdparty/minimap2/minimap2 ${CMAKE_CURRENT_BINARY_DIR}/bin/minimap2
@@ -582,7 +590,6 @@ set(BWA_SOURCES
     src/3rdparty/bwa/rle.c
     src/3rdparty/bwa/rope.c
     src/3rdparty/bwa/utils.c
-    src/mm_align.c
 )
 
 add_custom_target(build-deps DEPENDS

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,8 @@ channels:
 dependencies:
   - cmake
   - make
+  - ccache        # compiler cache; CMake auto-uses it. Unchanged TUs (mgsr.cpp ~25s
+                  # at -O3) are served from cache and survive `rm -rf build`.
   - compilers
   - pkg-config
   - git


### PR DESCRIPTION
## Summary

Build-process speedups (after #108). No change to any build output.

### Local / dev builds
- **Add `ccache` to `environment.yml`.** The CMakeLists already wires up ccache as the compiler launcher when present — it just wasn't installed, so every rebuild recompiled from scratch. With it, a `rm -rf build && cmake --build build` drops from **~2:46 to ~4 s** (heavy TUs — `mgsr.cpp`, generated protobuf — served from cache; survives a `build/` wipe).
- **Drop the duplicate `src/mm_align.c` from the `bwa` library** — already compiled into `panmap_lib`, so `libbwa`'s copy was a redundant second compile.
- **Build minimap2's nested `make` in parallel** — it inherited the parent job-server FDs it can't use (fell back to `-j1`, emitting two `make[3]` warnings); unset `MAKEFLAGS` + explicit `-j<ncpu>`.

### CI
- **`CCACHE_COMPILERCHECK=content`.** CI already caches ccache (`hendrikmuhs/ccache-action`), but it was silently getting **0% hits on any run where the conda env was rebuilt** (an `environment.yml` change — like adding ccache — or an env-cache miss). ccache's default `compiler_check=mtime` treats the re-extracted-but-identical conda toolchain as a new compiler and invalidates the whole cache. Measured in CI: build-test **100% hits** on stable-env runs, **0%** right after an env change. Hashing compiler *content* makes the cache survive re-extraction.

## Verification
Clean build: 0 compiler warnings, 0 make warnings, `mm_align.c` compiled once, links + runs, README demos reproduce (8/8). Warm rebuild after a `build/` wipe: ~4 s.

## Note
Existing environments need `conda install -n <env> ccache` (or recreate from `environment.yml`) to pick it up locally; the CMakeLists auto-detects it and is a no-op if absent.
