### PR TITLE
perf: link jemalloc (faster allocator)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -882,6 +882,19 @@ target_link_libraries(panmap_lib PUBLIC
 
 target_link_libraries(panmap PRIVATE panmap_lib)
 
+# jemalloc: interposing a fast allocator sharply cuts panmap's allocation churn
+# (single-thread placement ~20-25% faster, indexing a few %, no RAM cost, output
+# byte-identical). Optional -- fall back to the system allocator if absent. panmap
+# doesn't reference jemalloc symbols directly, so --no-as-needed keeps it in
+# DT_NEEDED (scoped to just this lib) so it actually interposes malloc.
+find_library(JEMALLOC_LIBRARY NAMES jemalloc)
+if(JEMALLOC_LIBRARY)
+    message(STATUS "Linking jemalloc: ${JEMALLOC_LIBRARY}")
+    target_link_libraries(panmap PRIVATE "-Wl,--no-as-needed,${JEMALLOC_LIBRARY},--as-needed")
+else()
+    message(STATUS "jemalloc not found; using the system allocator (placement will be slower)")
+endif()
+
 # Compiler options by build type, on panmap_lib PUBLIC so its sources compile with
 # them AND consumers inherit them.
 if(OPTION_DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -882,11 +882,6 @@ target_link_libraries(panmap_lib PUBLIC
 
 target_link_libraries(panmap PRIVATE panmap_lib)
 
-# jemalloc: interposing a fast allocator sharply cuts panmap's allocation churn
-# (single-thread placement ~20-25% faster, indexing a few %, no RAM cost, output
-# byte-identical). Optional -- fall back to the system allocator if absent. panmap
-# doesn't reference jemalloc symbols directly, so --no-as-needed keeps it in
-# DT_NEEDED (scoped to just this lib) so it actually interposes malloc.
 find_library(JEMALLOC_LIBRARY NAMES jemalloc)
 if(JEMALLOC_LIBRARY)
     message(STATUS "Linking jemalloc: ${JEMALLOC_LIBRARY}")

--- a/environment.yml
+++ b/environment.yml
@@ -30,5 +30,4 @@ dependencies:
   - libdeflate
   - zlib
   - eigen
-  - jemalloc      # allocator: interposed at link; cuts allocation churn (placement
-                  # ~20-25% faster at no RAM cost, output identical). Optional in CMake.
+  - jemalloc

--- a/environment.yml
+++ b/environment.yml
@@ -30,3 +30,5 @@ dependencies:
   - libdeflate
   - zlib
   - eigen
+  - jemalloc      # allocator: interposed at link; cuts allocation churn (placement
+                  # ~20-25% faster at no RAM cost, output identical). Optional in CMake.


### PR DESCRIPTION
Link `jemalloc` for faster allocations.

Timing results:

| stage | glibc | jemalloc |
|---|---|---|
| SARS index | 4.26 s | 3.93 s (**−8%**) |
| SARS place | 3.44 s | 2.96 s (**−14%**) |
| TB place | 6.57 s | 6.06 s (**−8%**) |
