### PR TITLE
perf(index): stop double decompression

### DIFF
--- a/src/index_single_mode.cpp
+++ b/src/index_single_mode.cpp
@@ -21,6 +21,8 @@
 #include <mutex>
 #include <iomanip>
 #include <utility>
+#include <cstring>
+#include <fstream>
 
 std::vector<panmapUtils::NewSyncmerRange> index_single_mode::IndexBuilder::computeNewSyncmerRangesJump(
     panmanUtils::Node* /*node*/,
@@ -1521,6 +1523,37 @@ void index_single_mode::IndexBuilder::computeSubstitutionSpectrum() {
     output::done("Substitution spectrum computed");
 }
 
+namespace index_single_mode {
+std::array<uint8_t, kIndexHeaderSize> encodeIndexHeader(const IndexParamsHeader& p) {
+    std::array<uint8_t, kIndexHeaderSize> h{};
+    auto put32 = [&](size_t off, uint32_t v) { std::memcpy(h.data() + off, &v, 4); };
+    put32(0, kIndexMagic);
+    put32(4, kIndexHeaderVersion);
+    put32(8, static_cast<uint32_t>(p.k));
+    put32(12, static_cast<uint32_t>(p.s));
+    put32(16, static_cast<uint32_t>(p.t));
+    put32(20, static_cast<uint32_t>(p.l));
+    h[24] = p.hpc ? 1 : 0;
+    h[25] = p.open ? 1 : 0;
+    return h;
+}
+
+bool readIndexHeader(const std::string& path, IndexParamsHeader& out) {
+    std::ifstream f(path, std::ios::binary);
+    std::array<uint8_t, kIndexHeaderSize> h{};
+    if (!f.read(reinterpret_cast<char*>(h.data()), kIndexHeaderSize)) return false;
+    auto get32 = [&](size_t off) { uint32_t v; std::memcpy(&v, h.data() + off, 4); return v; };
+    if (get32(0) != kIndexMagic || get32(4) != kIndexHeaderVersion) return false;
+    out.k = static_cast<int32_t>(get32(8));
+    out.s = static_cast<int32_t>(get32(12));
+    out.t = static_cast<int32_t>(get32(16));
+    out.l = static_cast<int32_t>(get32(20));
+    out.hpc = h[24] != 0;
+    out.open = h[25] != 0;
+    return true;
+}
+}  // namespace index_single_mode
+
 void index_single_mode::IndexBuilder::writeIndex(const std::string& path, int numThreads, int zstdLevel) {
     output::step("Serializing index...");
 
@@ -1530,9 +1563,21 @@ void index_single_mode::IndexBuilder::writeIndex(const std::string& path, int nu
 
     output::step("Writing index ({} bytes uncompressed)...", dataSize);
 
+    // Uncompressed param header: lets cache-validation read the seeding params without
+    // decompressing the payload (see readIndexHeader / cachedIndexUsable).
+    IndexParamsHeader ph;
+    ph.k = indexBuilder.getK();
+    ph.s = indexBuilder.getS();
+    ph.t = indexBuilder.getT();
+    ph.l = indexBuilder.getL();
+    ph.hpc = indexBuilder.getHpc();
+    ph.open = indexBuilder.getOpen();
+    const auto header = encodeIndexHeader(ph);
+
     // Many independent 64 MB frames so the index inflates in parallel on load.
     constexpr size_t kIndexFrameSize = 64ull * 1024 * 1024;
-    if (!panmap_zstd::compressToFile(data, dataSize, path, zstdLevel, numThreads, kIndexFrameSize)) {
+    if (!panmap_zstd::compressToFile(data, dataSize, path, zstdLevel, numThreads, kIndexFrameSize,
+                                     header.data(), header.size())) {
         output::error("failed to write compressed index to {}", path);
         std::exit(1);
     }

--- a/src/index_single_mode.hpp
+++ b/src/index_single_mode.hpp
@@ -15,8 +15,26 @@
 #include <atomic>
 #include <absl/container/btree_set.h>
 #include <absl/container/flat_hash_map.h>
+#include <array>
+#include <cstdint>
+#include <string>
 
 namespace index_single_mode {
+
+// A small uncompressed header prepended to the .idx so cache-validation can read the
+// seeding params without decompressing the (up to GB-scale) payload -- previously the
+// validation step fully decompressed the index just to read six fields, then the
+// placement step decompressed it a second time.
+constexpr uint32_t kIndexMagic = 0x31494D50u;  // "PMI1" little-endian
+constexpr uint32_t kIndexHeaderVersion = 1;
+constexpr size_t kIndexHeaderSize = 32;
+struct IndexParamsHeader {
+    int32_t k = 0, s = 0, t = 0, l = 0;
+    bool hpc = false, open = false;
+};
+std::array<uint8_t, kIndexHeaderSize> encodeIndexHeader(const IndexParamsHeader& p);
+// Reads the header from the start of `path`. Returns false if absent / not this format.
+bool readIndexHeader(const std::string& path, IndexParamsHeader& out);
 
 // btree_set has better cache locality than std::set
 using SyncmerSet = absl::btree_set<uint64_t>;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,7 +199,12 @@ class IndexReader : public ::capnp::MessageReader {
     std::unique_ptr<::capnp::FlatArrayMessageReader> reader;
 
     explicit IndexReader(const std::string& path, int numThreads = 0) : ::capnp::MessageReader(makeOptions()) {
-        if (!panmap_zstd::decompressFromFile(path, data, numThreads)) {
+        // New-format indexes carry a small uncompressed param header before the frames;
+        // skip it. Old-format indexes (no header) decompress from offset 0.
+        index_single_mode::IndexParamsHeader ph;
+        const size_t dataOffset =
+            index_single_mode::readIndexHeader(path, ph) ? index_single_mode::kIndexHeaderSize : 0;
+        if (!panmap_zstd::decompressFromFile(path, data, numThreads, dataOffset)) {
             throw std::runtime_error("Failed to decompress index: " + path);
         }
 
@@ -368,19 +373,20 @@ static bool cachedIndexUsable(const Config& cfg) {
             return false;
         }
     }
-    try {
-        IndexReader reader(cfg.index, cfg.threads);
-        auto idx = reader.getRoot<LiteIndex>();
-        if (idx.getK() != cfg.k || idx.getS() != cfg.s || idx.getT() != cfg.t || idx.getL() != cfg.l ||
-            idx.getHpc() != cfg.hpc || idx.getOpen() != cfg.openSyncmer) {
-            logging::warn(
-                "Cached index {} was built with different seeding parameters "
-                "(k/s/t/l/hpc/open-syncmer); rebuilding.",
-                cfg.index);
-            return false;
-        }
-    } catch (const std::exception& e) {
-        logging::warn("Cached index {} could not be read ({}); rebuilding.", cfg.index, e.what());
+    // Read the seeding params from the small uncompressed header instead of decompressing
+    // the whole (up to GB-scale) payload just to compare six fields.
+    index_single_mode::IndexParamsHeader ph;
+    if (!index_single_mode::readIndexHeader(cfg.index, ph)) {
+        logging::warn("Cached index {} has no readable param header (old format/corrupt); rebuilding.",
+                      cfg.index);
+        return false;
+    }
+    if (ph.k != cfg.k || ph.s != cfg.s || ph.t != cfg.t || ph.l != cfg.l ||
+        ph.hpc != cfg.hpc || ph.open != cfg.openSyncmer) {
+        logging::warn(
+            "Cached index {} was built with different seeding parameters "
+            "(k/s/t/l/hpc/open-syncmer); rebuilding.",
+            cfg.index);
         return false;
     }
     return true;

--- a/src/test/helpers/test_index.cpp
+++ b/src/test/helpers/test_index.cpp
@@ -25,7 +25,11 @@ std::string makeTempIndexPath() {
 
 IndexData loadIndex(const std::string& path) {
     std::vector<uint8_t> buffer;
-    if (!panmap_zstd::decompressFromFile(path, buffer)) {
+    // Skip the uncompressed param header prepended by writeIndex (see readIndexHeader).
+    index_single_mode::IndexParamsHeader ph;
+    const size_t dataOffset =
+        index_single_mode::readIndexHeader(path, ph) ? index_single_mode::kIndexHeaderSize : 0;
+    if (!panmap_zstd::decompressFromFile(path, buffer, 0, dataOffset)) {
         throw std::runtime_error("Failed to decompress index: " + path);
     }
 

--- a/src/zstd_compression.cpp
+++ b/src/zstd_compression.cpp
@@ -17,7 +17,9 @@ bool compressToFile(const void* inputData,
                     const std::string& outputPath,
                     int compressionLevel,
                     int numThreads,
-                    size_t frameSize) {
+                    size_t frameSize,
+                    const void* headerData,
+                    size_t headerSize) {
     if (numThreads == 0) {
         numThreads = std::thread::hardware_concurrency();
     }
@@ -76,6 +78,9 @@ bool compressToFile(const void* inputData,
         logging::err("Failed to open output file: {}", outputPath);
         return false;
     }
+    if (headerData != nullptr && headerSize > 0) {  // uncompressed prefix (e.g. index params)
+        outFile.write(reinterpret_cast<const char*>(headerData), static_cast<std::streamsize>(headerSize));
+    }
     size_t compressedSize = 0;
     for (const auto& f : frames) {  // concatenate frames in order
         outFile.write(reinterpret_cast<const char*>(f.data()), static_cast<std::streamsize>(f.size()));
@@ -103,7 +108,8 @@ bool compressToFile(const void* inputData,
     return true;
 }
 
-bool decompressFromFile(const std::string& inputPath, std::vector<uint8_t>& outputData, int numThreads) {
+bool decompressFromFile(const std::string& inputPath, std::vector<uint8_t>& outputData, int numThreads,
+                        size_t dataOffset) {
     if (numThreads == 0) {
         numThreads = std::thread::hardware_concurrency();
     }
@@ -132,7 +138,7 @@ bool decompressFromFile(const std::string& inputPath, std::vector<uint8_t>& outp
     // only the first frame (indexes are written multi-frame).
     size_t numFrames = 0;
     unsigned long long decompressedSize = 0;
-    size_t pos = 0;
+    size_t pos = dataOffset;  // skip an uncompressed header prefix, if any
     while (pos < compressedSize) {
         unsigned long long frameCompSize = ZSTD_findFrameCompressedSize(compressedData + pos, compressedSize - pos);
         if (ZSTD_isError(frameCompSize)) {
@@ -164,7 +170,7 @@ bool decompressFromFile(const std::string& inputPath, std::vector<uint8_t>& outp
         std::vector<std::pair<size_t, size_t>> frameRanges;
         std::vector<std::pair<size_t, size_t>> outputRanges;
 
-        pos = 0;
+        pos = dataOffset;  // frames begin after the uncompressed header
         size_t outPos = 0;
         while (pos < compressedSize) {
             unsigned long long frameCompSize = ZSTD_findFrameCompressedSize(compressedData + pos, compressedSize - pos);
@@ -219,7 +225,7 @@ bool decompressFromFile(const std::string& inputPath, std::vector<uint8_t>& outp
         }
 
         // ZSTD_decompressDCtx handles one frame; walk them for multi-frame input.
-        size_t inPos = 0;
+        size_t inPos = dataOffset;  // frames begin after the uncompressed header
         size_t outPos = 0;
         while (inPos < compressedSize) {
             unsigned long long frameCompSize =

--- a/src/zstd_compression.hpp
+++ b/src/zstd_compression.hpp
@@ -17,14 +17,18 @@ namespace panmap_zstd {
                                   const std::string& outputPath,
                                   int compressionLevel = 3,
                                   int numThreads = 0,
-                                  size_t frameSize = 4 * 1024 * 1024  // 4MB frames
+                                  size_t frameSize = 4 * 1024 * 1024,  // 4MB frames
+                                  const void* headerData = nullptr,    // optional uncompressed prefix,
+                                  size_t headerSize = 0                // written verbatim before the frames
 );
 
 /**
  * Decompress inputPath into outputData (resized to fit) with parallel ZSTD.
- * numThreads: 0 = auto-detect. Returns true on success.
+ * numThreads: 0 = auto-detect. dataOffset: skip this many leading bytes (an
+ * uncompressed header) before the ZSTD frames. Returns true on success.
  */
 [[nodiscard]] bool
-decompressFromFile(const std::string& inputPath, std::vector<uint8_t>& outputData, int numThreads = 0);
+decompressFromFile(const std::string& inputPath, std::vector<uint8_t>& outputData, int numThreads = 0,
+                   size_t dataOffset = 0);
 
 }  // namespace panmap_zstd


### PR DESCRIPTION
Prepend a 32-byte uncompressed header to the index to eliminate decompression pass for index validation/parameter checking