### PR TITLE
fix(index): collapse per-node syncmer change record to one entry per position

### DIFF
--- a/src/index_single_mode.cpp
+++ b/src/index_single_mode.cpp
@@ -699,12 +699,8 @@ index_single_mode::IndexBuilder::computeNewKminmerRanges(
 }
 
 namespace {
-// Collapse a node's change record to one net entry per position. A node that both edits a
-// seed and deletes that seed's block records the position twice (SUB/ADD, then DEL), but the
-// consumers assume one entry -- the stale non-DEL entry names a position the DEL already
-// erased, so computeNewKminmerRanges' find() fails and the backtrack restores a wrong value.
-// Net kind = whether the position survives to the node's end (final map); restore value = the
-// first (pre-node) entry. No-op when no position repeats.
+// Collapse a node's change record to one net entry per position, to handle a node that both edits a
+// seed and deletes that seed's block.
 void dedupeSyncmerChangeRecord(
     std::vector<std::tuple<uint64_t, panmapUtils::seedChangeType, seeding::rsyncmer_t>>& rec,
     const index_single_mode::SyncmerSet& finalMap) {

--- a/src/index_single_mode.cpp
+++ b/src/index_single_mode.cpp
@@ -18,6 +18,7 @@
 #include <bitset>
 #include <chrono>
 #include <atomic>
+#include <unordered_map>
 #include <mutex>
 #include <iomanip>
 #include <utility>
@@ -697,6 +698,47 @@ index_single_mode::IndexBuilder::computeNewKminmerRanges(
     return newKminmerRanges;
 }
 
+namespace {
+// Collapse a node's change record to one net entry per position. A node that both edits a
+// seed and deletes that seed's block records the position twice (SUB/ADD, then DEL), but the
+// consumers assume one entry -- the stale non-DEL entry names a position the DEL already
+// erased, so computeNewKminmerRanges' find() fails and the backtrack restores a wrong value.
+// Net kind = whether the position survives to the node's end (final map); restore value = the
+// first (pre-node) entry. No-op when no position repeats.
+void dedupeSyncmerChangeRecord(
+    std::vector<std::tuple<uint64_t, panmapUtils::seedChangeType, seeding::rsyncmer_t>>& rec,
+    const index_single_mode::SyncmerSet& finalMap) {
+    if (rec.size() < 2) return;
+    std::unordered_map<uint64_t, std::pair<panmapUtils::seedChangeType, seeding::rsyncmer_t>> firstTouch;
+    firstTouch.reserve(rec.size());
+    std::vector<uint64_t> order;
+    order.reserve(rec.size());
+    bool anyRepeat = false;
+    for (const auto& [pos, type, rsync] : rec) {
+        auto [it, inserted] = firstTouch.try_emplace(pos, type, rsync);
+        if (inserted)
+            order.push_back(pos);
+        else
+            anyRepeat = true;
+    }
+    if (!anyRepeat) return;
+    std::vector<std::tuple<uint64_t, panmapUtils::seedChangeType, seeding::rsyncmer_t>> out;
+    out.reserve(order.size());
+    for (uint64_t pos : order) {
+        const auto& [firstType, firstRsync] = firstTouch[pos];
+        const bool finalHas = finalMap.find(pos) != finalMap.end();
+        if (firstType == panmapUtils::seedChangeType::ADD) {  // parent lacked pos; keep only if it survives
+            if (finalHas) out.emplace_back(pos, panmapUtils::seedChangeType::ADD, seeding::rsyncmer_t());
+        } else {  // parent had pos; restore its pre-node value
+            out.emplace_back(pos,
+                             finalHas ? panmapUtils::seedChangeType::SUB : panmapUtils::seedChangeType::DEL,
+                             firstRsync);
+        }
+    }
+    rec = std::move(out);
+}
+}  // namespace
+
 void index_single_mode::IndexBuilder::buildIndexHelper(panmanUtils::Node* node,
                                                        std::unordered_set<std::string_view>& emptyNodes,
                                                        panmapUtils::BlockSequences& blockSequences,
@@ -929,6 +971,7 @@ void index_single_mode::IndexBuilder::buildIndexHelper(panmanUtils::Node* node,
         }
     }
 
+    dedupeSyncmerChangeRecord(refOnSyncmersChangeRecord, refOnSyncmersMap);
     std::vector<std::pair<index_single_mode::SyncmerSet::iterator, index_single_mode::SyncmerSet::iterator>>
         newKminmerRanges = computeNewKminmerRanges(refOnSyncmersChangeRecord, dfsIndex);
 
@@ -1916,6 +1959,7 @@ void index_single_mode::IndexBuilder::processNode(panmanUtils::Node* node,
     std::vector<uint64_t> addedSeedHashes;
     std::vector<std::pair<uint64_t, uint64_t>> substitutedSeedHashes;  // <oldHash, newHash>
 
+    dedupeSyncmerChangeRecord(refOnSyncmersChangeRecord, state.refOnSyncmersMap);
     std::vector<std::pair<index_single_mode::SyncmerSet::iterator, index_single_mode::SyncmerSet::iterator>>
         newKminmerRanges = computeNewKminmerRanges(refOnSyncmersChangeRecord, state, dfsIndex);
 

--- a/src/mgsr.cpp
+++ b/src/mgsr.cpp
@@ -10,6 +10,7 @@
 #include <tbb/enumerable_thread_specific.h>
 #include <random>
 #include <numeric>
+#include <unordered_map>
 #include <algorithm>
 #include <stack>
 #include <bitset>
@@ -3259,6 +3260,45 @@ std::vector<panmapUtils::NewSyncmerRange> mgsr::mgsrIndexBuilder::computeNewSync
     return newSyncmerRanges;
 }
 
+namespace {
+// Collapse a node's change record to one net entry per position (see the twin in
+// index_single_mode.cpp for the full rationale). The same node-edits-a-seed-then-deletes-its-
+// block case leaves a stale entry that here derefs an already-cleared refOnSyncmers optional
+// -> bad_optional_access. Net kind = final-map membership; restore = first (pre-node) entry.
+void dedupeSyncmerChangeRecord(
+    std::vector<std::tuple<uint64_t, panmapUtils::seedChangeType, seeding::rsyncmer_t>>& rec,
+    const std::set<uint64_t>& finalMap) {
+    if (rec.size() < 2) return;
+    std::unordered_map<uint64_t, std::pair<panmapUtils::seedChangeType, seeding::rsyncmer_t>> firstTouch;
+    firstTouch.reserve(rec.size());
+    std::vector<uint64_t> order;
+    order.reserve(rec.size());
+    bool anyRepeat = false;
+    for (const auto& [pos, type, rsync] : rec) {
+        auto [it, inserted] = firstTouch.try_emplace(pos, type, rsync);
+        if (inserted)
+            order.push_back(pos);
+        else
+            anyRepeat = true;
+    }
+    if (!anyRepeat) return;
+    std::vector<std::tuple<uint64_t, panmapUtils::seedChangeType, seeding::rsyncmer_t>> out;
+    out.reserve(order.size());
+    for (uint64_t pos : order) {
+        const auto& [firstType, firstRsync] = firstTouch[pos];
+        const bool finalHas = finalMap.find(pos) != finalMap.end();
+        if (firstType == panmapUtils::seedChangeType::ADD) {
+            if (finalHas) out.emplace_back(pos, panmapUtils::seedChangeType::ADD, seeding::rsyncmer_t());
+        } else {
+            out.emplace_back(pos,
+                             finalHas ? panmapUtils::seedChangeType::SUB : panmapUtils::seedChangeType::DEL,
+                             firstRsync);
+        }
+    }
+    rec = std::move(out);
+}
+}  // namespace
+
 std::vector<std::pair<std::set<uint64_t>::iterator, std::set<uint64_t>::iterator>>
 mgsr::mgsrIndexBuilder::computeNewKminmerRanges(
     std::vector<std::tuple<uint64_t, panmapUtils::seedChangeType, seeding::rsyncmer_t>>& refOnSyncmersChangeRecord,
@@ -3584,6 +3624,9 @@ void mgsr::mgsrIndexBuilder::buildIndexHelper(panmanUtils::Node* node,
         if (oldExists && !newExists) {
             if (blockOnSyncmers.find(blockId) != blockOnSyncmers.end()) {
                 for (uint64_t pos : blockOnSyncmers[blockId]) {
+                    // Skip: this position was already deleted earlier in this node (its
+                    // blockOnSyncmers cleanup is deferred), so refOnSyncmers is nullopt here.
+                    if (!refOnSyncmers[pos].has_value()) continue;
                     refOnSyncmersChangeRecord.emplace_back(
                         pos, panmapUtils::seedChangeType::DEL, refOnSyncmers[pos].value());
                     blockOnSyncmersChangeRecord.emplace_back(blockId, pos, panmapUtils::seedChangeType::DEL);
@@ -3596,6 +3639,7 @@ void mgsr::mgsrIndexBuilder::buildIndexHelper(panmanUtils::Node* node,
         }
     }
 
+    dedupeSyncmerChangeRecord(refOnSyncmersChangeRecord, refOnSyncmersMap);
     std::vector<std::pair<std::set<uint64_t>::iterator, std::set<uint64_t>::iterator>> newKminmerRanges =
         computeNewKminmerRanges(refOnSyncmersChangeRecord, dfsIndex);
 

--- a/src/mgsr.cpp
+++ b/src/mgsr.cpp
@@ -3261,10 +3261,7 @@ std::vector<panmapUtils::NewSyncmerRange> mgsr::mgsrIndexBuilder::computeNewSync
 }
 
 namespace {
-// Collapse a node's change record to one net entry per position (see the twin in
-// index_single_mode.cpp for the full rationale). The same node-edits-a-seed-then-deletes-its-
-// block case leaves a stale entry that here derefs an already-cleared refOnSyncmers optional
-// -> bad_optional_access. Net kind = final-map membership; restore = first (pre-node) entry.
+// Collapse a node's change record to one net entry per position
 void dedupeSyncmerChangeRecord(
     std::vector<std::tuple<uint64_t, panmapUtils::seedChangeType, seeding::rsyncmer_t>>& rec,
     const std::set<uint64_t>& finalMap) {


### PR DESCRIPTION
Fixes `klebs_1000.panman` crash:
- **placement / `.idx`** (`--stop index`): `error: syncmer position not found in refOnSyncmersMap when computing new k-min-mer ranges` (fails identically at k=51 and k=19).
- **metagenomic / `.midx`** (`--meta`): `error: bad optional access`.

When a node both edits a seed and deletes that seed's block, we recorded the same position twice in its per-node change record leading to crash.

Fix: collapse each node's change record to one net entry per position.
